### PR TITLE
Create workflow `selfassign.yml`

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -1,0 +1,24 @@
+# Allow users to automatically tag themselves to issues
+#
+# Usage:
+#  - a github user (a member of the repo) needs to comment
+#    with "#self-assign" on an issue to be assigned to them.
+#------------------------------------------------------------
+
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          echo "Done 🔥 "


### PR DESCRIPTION
This allows repository contributors to self-assign an issue by just adding a comment `#self-assign` to the issue. 

- Helps the repo-maintainers to do one less thing! :hugs: 

Closes #28 