### PR TITLE
[FIX] Examples numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPi](https://img.shields.io/pypi/v/hierarchicalforecast?color=blue)](https://pypi.org/project/hierarchicalforecast/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Nixtla/hierarchicalforecast/blob/main/LICENSE)
     
-**HierarchicalForecast** offers a collection of reconciliation methods, including `BottomUp`, `TopDown`, `MiddleOut`, `MinTrace` and `ERM`. And Probabilistic coherent predictions including `MinTrace-normality`, `Bootstrap`, and `PERM-BU`.
+**HierarchicalForecast** offers a collection of reconciliation methods, including `BottomUp`, `TopDown`, `MiddleOut`, `MinTrace` and `ERM`. And Probabilistic coherent predictions including `Normality`, `Bootstrap`, and `PERMBU`.
 </div>
 
 ## 🎊 Features 
@@ -23,9 +23,9 @@
     - `MinTrace`: Minimizes the total forecast variance of the space of coherent forecasts, with the Minimum Trace reconciliation.
     - `ERM`: Optimizes the reconciliation matrix minimizing an L1 regularized objective.
 * Probabilistic coherent methods:
-    - `MinTrace-normality`: Uses MinTrace variance-covariance closed form matrix under a normality assumption.
+    - `Normality`: Uses MinTrace variance-covariance closed form matrix under a normality assumption.
     - `Bootstrap`: Generates distribution of hierarchically reconciled predictions using Gamakumara's bootstrap approach.
-    - `PERM-BU`: Reconciles independent sample predictions by reinjecting multivariate dependence with estimated rank permutation copulas, and performing a Bottom-Up aggregation.
+    - `PERMBU`: Reconciles independent sample predictions by reinjecting multivariate dependence with estimated rank permutation copulas, and performing a Bottom-Up aggregation.
 
 Missing something? Please open an issue here or write us in [![Slack](https://img.shields.io/badge/Slack-4A154B?&logo=slack&logoColor=white)](https://join.slack.com/t/nixtlaworkspace/shared_invite/zt-135dssye9-fWTzMpv2WBthq8NK0Yvu6A)
 

--- a/nbs/examples/AustralianDomesticTourism-Bootstraped-Intervals.ipynb
+++ b/nbs/examples/AustralianDomesticTourism-Bootstraped-Intervals.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 5. Reconciled Probabilistic Forecasts (Bootstrap)"
+    "# • Reconciled Probabilistic Forecasts (Bootstrap)"
    ]
   },
   {

--- a/nbs/examples/AustralianDomesticTourism-Intervals.ipynb
+++ b/nbs/examples/AustralianDomesticTourism-Intervals.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 4. Reconciled Probabilistic Forecasts (Normality)"
+    "# • Reconciled Probabilistic Forecasts (Normality)"
    ]
   },
   {

--- a/nbs/examples/AustralianDomesticTourism-Permbu-Intervals.ipynb
+++ b/nbs/examples/AustralianDomesticTourism-Permbu-Intervals.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 6. Reconciled Probabilistic Forecasts (PERMBU)"
+    "# • Reconciled Probabilistic Forecasts (PERMBU)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/6AustralianDomesticTourism-Permbu-Intervals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/AustralianDomesticTourism-Permbu-Intervals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -1072,7 +1072,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/6AustralianDomesticTourism-Permbu-Intervals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/AustralianDomesticTourism-Permbu-Intervals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   }
  ],

--- a/nbs/examples/AustralianDomesticTourism.ipynb
+++ b/nbs/examples/AustralianDomesticTourism.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 2. R's Fable/HTS Replication1"
+    "# • R's Fable/HTS Replication1"
    ]
   },
   {
@@ -1000,9 +1000,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hierarchicalforecast",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "hierarchicalforecast"
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/nbs/examples/AustralianPrisonPopulation.ipynb
+++ b/nbs/examples/AustralianPrisonPopulation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 3. R's Fable/HTS Replication2"
+    "# • R's Fable/HTS Replication2"
    ]
   },
   {
@@ -794,9 +794,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hierarchicalforecast",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "hierarchicalforecast"
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/nbs/examples/NonNegativeReconciliation.ipynb
+++ b/nbs/examples/NonNegativeReconciliation.ipynb
@@ -5,7 +5,7 @@
    "id": "843cf8de-d678-4243-a8af-d78439058e6a",
    "metadata": {},
    "source": [
-    "# 7. Non-Negative Hierarchical Reconciliation"
+    "# • Non-Negative Hierarchical Reconciliation"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "e9e5cafc-68db-4752-bfe0-b360cd8d9e1f",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/7NonNegativeReconciliation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/NonNegativeReconciliation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -1050,10 +1050,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "978eb2d1-31cb-45e2-a934-729cb5974e5c",
+   "id": "835af2e2-5825-4e28-a684-69beb0fd6bb3",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/7NonNegativeReconciliation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/hierarchicalforecast/blob/main/nbs/examples/NonNegativeReconciliation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   }
  ],

--- a/nbs/examples/TourismSmall.ipynb
+++ b/nbs/examples/TourismSmall.ipynb
@@ -5,7 +5,7 @@
    "id": "843cf8de-d678-4243-a8af-d78439058e6a",
    "metadata": {},
    "source": [
-    "# 1. Reconciliation Quick Start"
+    "# • Hierarchical Reconciliation Quick Start"
    ]
   },
   {
@@ -569,9 +569,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hierarchicalforecast",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "hierarchicalforecast"
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -5,7 +5,7 @@
    "id": "018f6145-b103-4f3e-b4cd-0aab4d8bbdb7",
    "metadata": {},
    "source": [
-    "# 👑 Hierarchical Forecast"
+    "# Hierarchical 👑  Forecast"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "source": [
     "Large collections of time series organized into structures at different aggregation levels often require their forecasts to follow their aggregation constraints, which poses the challenge of creating novel algorithms capable of coherent forecasts.\n",
     "\n",
-    "**HierarchicalForecast** offers a collection of reconciliation methods, including `BottomUp`, `TopDown`, `MiddleOut`, `MinTrace` and `ERM`. Along with data wrangling, evaluation and visualization tools for grouped and hierarchical series. And Probabilistic coherent predictions including `MinTrace-normality`, `Bootstrap`, and `PERM-BU` methods."
+    "**HierarchicalForecast** offers a collection of reconciliation methods, including `BottomUp`, `TopDown`, `MiddleOut`, `MinTrace` and `ERM`. And Probabilistic coherent predictions including `Normality`, `Bootstrap`, and `PERMBU`."
    ]
   },
   {
@@ -33,9 +33,9 @@
     "    - `MinTrace`: Minimizes the total forecast variance of the space of coherent forecasts, with the Minimum Trace reconciliation.\n",
     "    - `ERM`: Optimizes the reconciliation matrix minimizing an L1 regularized objective.\n",
     "* Probabilistic coherent methods:\n",
-    "    - `MinTrace-normality`: Uses MinTrace variance-covariance closed form matrix under a normality assumption.\n",
+    "    - `Normality`: Uses MinTrace variance-covariance closed form matrix under a normality assumption.\n",
     "    - `Bootstrap`: Generates distribution of hierarchically reconciled predictions using Gamakumara's bootstrap approach.\n",
-    "    - `PERM-BU`: Minimizes the total forecast variance of the space of coherent forecasts, with the Minimum Trace reconciliation.\n",
+    "    - `PERMBU`: Minimizes the total forecast variance of the space of coherent forecasts, with the Minimum Trace reconciliation.\n",
     "\n",
     "Missing something? Please open an issue here or write us in [![Slack](https://img.shields.io/badge/Slack-4A154B?&logo=slack&logoColor=white)](https://join.slack.com/t/nixtlaworkspace/shared_invite/zt-135dssye9-fWTzMpv2WBthq8NK0Yvu6A)\n"
    ]
@@ -108,41 +108,43 @@
     "\n",
     "#obtain hierarchical dataset\n",
     "from datasetsforecast.hierarchical import HierarchicalData\n",
+    "\n",
+    "# compute base forecast no coherent\n",
+    "from statsforecast.core import StatsForecast\n",
+    "from statsforecast.models import AutoARIMA, Naive\n",
+    "\n",
     "#obtain hierarchical reconciliation methods and evaluation\n",
     "from hierarchicalforecast.core import HierarchicalReconciliation\n",
     "from hierarchicalforecast.evaluation import HierarchicalEvaluation\n",
     "from hierarchicalforecast.methods import BottomUp, TopDown, MiddleOut\n",
-    "# compute base forecast no coherent\n",
-    "from statsforecast.core import StatsForecast\n",
-    "from statsforecast.models import AutoARIMA, Naive\n",
+    "\n",
     "\n",
     "# Load TourismSmall dataset\n",
     "Y_df, S, tags = HierarchicalData.load('./data', 'TourismSmall')\n",
     "Y_df['ds'] = pd.to_datetime(Y_df['ds'])\n",
     "\n",
     "#split train/test sets\n",
-    "Y_df_test = Y_df.groupby('unique_id').tail(12)\n",
-    "Y_df_train = Y_df.drop(Y_df_test.index)\n",
-    "Y_df_test = Y_df_test.set_index('unique_id')\n",
-    "Y_df_train = Y_df_train.set_index('unique_id')\n",
+    "Y_test_df  = Y_df.groupby('unique_id').tail(12)\n",
+    "Y_train_df = Y_df.drop(Y_test_df.index)\n",
+    "Y_test_df  = Y_test_df.set_index('unique_id')\n",
+    "Y_train_df = Y_train_df.set_index('unique_id')\n",
     "\n",
     "# Compute base auto-ARIMA predictions\n",
-    "fcst = StatsForecast(\n",
-    "    df=Y_df_train, \n",
-    "    models=[AutoARIMA(season_length=12), Naive()], \n",
-    "    freq='M', \n",
-    "    n_jobs=-1\n",
-    ")\n",
+    "fcst = StatsForecast(df=Y_train_df, \n",
+    "                     models=[AutoARIMA(season_length=12), Naive()], \n",
+    "                     freq='M', n_jobs=-1)\n",
     "Y_hat_df = fcst.forecast(h=12)\n",
     "\n",
     "# Reconcile the base predictions\n",
     "reconcilers = [\n",
     "    BottomUp(),\n",
     "    TopDown(method='forecast_proportions'),\n",
-    "    MiddleOut(level='Country/Purpose/State', top_down_method='forecast_proportions')\n",
+    "    MiddleOut(middle_level='Country/Purpose/State',\n",
+    "              top_down_method='forecast_proportions')\n",
     "]\n",
     "hrec = HierarchicalReconciliation(reconcilers=reconcilers)\n",
-    "Y_rec_df = hrec.reconcile(Y_hat_df, Y_df_train, S, tags)\n",
+    "Y_rec_df = hrec.reconcile(Y_hat_df=Y_hat_df, Y_df=Y_train_df, \n",
+    "                          S=S, tags=tags)\n",
     "```"
    ]
   },

--- a/nbs/sidebar.yml
+++ b/nbs/sidebar.yml
@@ -10,10 +10,10 @@ website:
         - utils.ipynb
       - section: Tutorials
         contents:
-        - examples/1TourismSmall.ipynb
-        - examples/2AustralianDomesticTourism.ipynb
-        - examples/3AustralianPrisonPopulation.ipynb
-        - examples/4AustralianDomesticTourism-Intervals.ipynb
-        - examples/5AustralianDomesticTourism-Bootstraped-Intervals.ipynb
-        - examples/6AustralianDomesticTourism-Permbu-Intervals.ipynb
-        - examples/7NonNegativeReconciliation.ipynb
+        - examples/TourismSmall.ipynb
+        - examples/AustralianDomesticTourism.ipynb
+        - examples/AustralianPrisonPopulation.ipynb
+        - examples/AustralianDomesticTourism-Intervals.ipynb
+        - examples/AustralianDomesticTourism-Bootstraped-Intervals.ipynb
+        - examples/AustralianDomesticTourism-Permbu-Intervals.ipynb
+        - examples/NonNegativeReconciliation.ipynb


### PR DESCRIPTION
This PR recovers unnumbered tutorials. Instead of a number, a bullet was used. 
This change solves:
- Colab broken links.
- Hierarchical emoji.
- Example code in `nbs/index.ipynb`
- Maintenance complexity due to numbers. 