### PR TITLE
[FIX] Add correct link to StatsForecast

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -29,7 +29,7 @@ website:
           - text: "NeuralForecast 🧠"
             href: https://github.com/nixtla/neuralforecast
           - text: "StatsForecast ⚡️"
-            href: https://github.com/nixtla/neuralforecast
+            href: https://github.com/nixtla/statsforecast
           
       - text: "Help"
         menu:


### PR DESCRIPTION
The link from nixtlaverse to statsforecast was referencing neuralforecast﻿
