### PR TITLE
[FEAT] Ignore jupyter notebooks as part of `languages`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.ipynb merge=nbdev-merge
 nbs/** linguist-documentation
+experiments/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ipynb merge=nbdev-merge
+nbs/** linguist-documentation


### PR DESCRIPTION
This PR allows to ignore jupyter notebooks in the language part of the repo:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/10517170/205808351-7f724735-83e0-4ff0-8262-5b637cbcb50a.png">

Before the change, the language stats were,

<img width="510" alt="image" src="https://user-images.githubusercontent.com/10517170/205808377-9c92ab23-63fc-429d-a8c6-cbabe0ceb05c.png">



After the change,

<img width="649" alt="image" src="https://user-images.githubusercontent.com/10517170/205808283-6f4c169f-9aff-479a-b7d5-76529ff5d6e5.png">
