### PR TITLE
[FIX] Matplotlib and numba errors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab
-  - numpy
+  - numpy<1.24
   - numba
   - pandas
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scikit-learn
   - quadprog
   - matplotlib
+  - tqdm
   - pip
   - pip:
     - nbdev
-    - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - scikit-learn
   - quadprog
+  - matplotlib
   - pip
   - pip:
     - nbdev

--- a/hierarchicalforecast/utils.py
+++ b/hierarchicalforecast/utils.py
@@ -192,8 +192,8 @@ class HierarchicalPlot:
                         continue
                     ax.fill_between(
                         df_plot.index, 
-                        df_plot[f'{col}-lo-{lv}'], 
-                        df_plot[f'{col}-hi-{lv}'],
+                        df_plot[f'{col}-lo-{lv}'].values, 
+                        df_plot[f'{col}-hi-{lv}'].values,
                         alpha=-lv/100 + 1,
                         color=cmap_dict[col],
                         label=f'{col}_level_{lv}'
@@ -248,8 +248,8 @@ class HierarchicalPlot:
                             continue
                         axs[idx].fill_between(
                             df_plot.index, 
-                            df_plot[f'{col}-lo-{lv}'], 
-                            df_plot[f'{col}-hi-{lv}'],
+                            df_plot[f'{col}-lo-{lv}'].values, 
+                            df_plot[f'{col}-hi-{lv}'].values,
                             alpha=-lv/100 + 1,
                             color=cmap_dict[col],
                             label=f'{col}_level_{lv}'

--- a/nbs/utils.ipynb
+++ b/nbs/utils.ipynb
@@ -331,8 +331,8 @@
     "                        continue\n",
     "                    ax.fill_between(\n",
     "                        df_plot.index, \n",
-    "                        df_plot[f'{col}-lo-{lv}'], \n",
-    "                        df_plot[f'{col}-hi-{lv}'],\n",
+    "                        df_plot[f'{col}-lo-{lv}'].values, \n",
+    "                        df_plot[f'{col}-hi-{lv}'].values,\n",
     "                        alpha=-lv/100 + 1,\n",
     "                        color=cmap_dict[col],\n",
     "                        label=f'{col}_level_{lv}'\n",
@@ -387,8 +387,8 @@
     "                            continue\n",
     "                        axs[idx].fill_between(\n",
     "                            df_plot.index, \n",
-    "                            df_plot[f'{col}-lo-{lv}'], \n",
-    "                            df_plot[f'{col}-hi-{lv}'],\n",
+    "                            df_plot[f'{col}-lo-{lv}'].values, \n",
+    "                            df_plot[f'{col}-hi-{lv}'].values,\n",
     "                            alpha=-lv/100 + 1,\n",
     "                            color=cmap_dict[col],\n",
     "                            label=f'{col}_level_{lv}'\n",
@@ -654,7 +654,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 2
-requirements = numpy numba pandas scikit-learn quadprog matplotlib tqdm
+requirements = numpy<1.24 numba pandas scikit-learn quadprog matplotlib tqdm
 dev_requirements = datasetsforecast statsforecast>=1.0.0 requests
 nbs_path = nbs
 doc_path = _docs


### PR DESCRIPTION
This PR fixes problems related to the latest release of numpy.
See https://github.com/numba/numba/issues/8615.
The `fill_between` function works as expected with the proposed change and the latest version of numpy.
`numba` however continues to fail. 
Pinning the numpy version fixes the issue.


- fix: add missing matplotlib dep to environment
- fix: add tqdm to conda deps
