### PR TITLE
Fix assignment to unbound variable

### DIFF
--- a/hierarchicalforecast/utils.py
+++ b/hierarchicalforecast/utils.py
@@ -227,6 +227,7 @@ def aggregate(df: pd.DataFrame,
         balanced_df['y'].fillna(0, inplace=True)
         Y_bottom_df.reset_index(inplace=True)
     else:
+        dates       = Y_bottom_df['ds'].unique()
         balanced_df = Y_bottom_df.copy()
 
     #------------------------------- Aggregation -------------------------------#

--- a/nbs/utils.ipynb
+++ b/nbs/utils.ipynb
@@ -322,6 +322,7 @@
     "        balanced_df['y'].fillna(0, inplace=True)\n",
     "        Y_bottom_df.reset_index(inplace=True)\n",
     "    else:\n",
+    "        dates       = Y_bottom_df['ds'].unique()\n",
     "        balanced_df = Y_bottom_df.copy()\n",
     "\n",
     "    #------------------------------- Aggregation -------------------------------#\n",


### PR DESCRIPTION
When specifying `is_balanced=True` in `aggregate` function, we get the following error:

```
UnboundLocalError: local variable 'dates' referenced before assignment
```

This happens because `dates` is defined only in not balanced case.

```python
    if not is_balanced:
        dates         = Y_bottom_df['ds'].unique()
        [...]
    else:
        balanced_df = Y_bottom_df.copy()
        # `dates` is not defined in this if-else branch 
```

Suggested fix: define it in the balanced case too:
```python
    if not is_balanced:
        dates         = Y_bottom_df['ds'].unique()
        [...]
    else:
        dates       = Y_bottom_df['ds'].unique()
        balanced_df = Y_bottom_df.copy()
```


## Test

Code which fails before the proposed fix:

```python
import random
from datetime import date, timedelta

import pandas as pd

from hierarchicalforecast.utils import aggregate

# Create a sample data frame
random.seed(2023)
T = 5
n_bottom = 4

df = pd.DataFrame(
    {
        "level_1": ["a"] * T * 2 + ["b"] * T * 2,
        "level_2": [chr(ord("c") + i) for i in range(n_bottom) for _ in range(T)],
        "y": [random.randint(2, 4) for i in range(n_bottom) for _ in range(T)],
        "ds": [date(year=2023, month=1, day=1) + timedelta(days=Δ) for Δ in range(T)] * n_bottom,
    }
)
print(df)
#   level_1 level_2  y          ds
# 0       a       c  3  2023-01-01
# 1       a       c  4  2023-01-02
# 2       a       d  3  2023-01-01
# 3       a       d  3  2023-01-02
# 4       b       e  3  2023-01-01
# 5       b       e  4  2023-01-02
# 6       b       f  4  2023-01-01
# 7       b       f  3  2023-01-02

# Aggregate
hierarchy_levels = [
    ["level_1"],
    ["level_1", "level_2"],
]

df, S, tags = aggregate(df=df, spec=hierarchy_levels, is_balanced=True)
```
results in 
```
UnboundLocalError: local variable 'dates' referenced before assignment
```
