### PR TITLE
[Doc] Fix intro installation typo

### DIFF
--- a/nbs/examples/Installation.ipynb
+++ b/nbs/examples/Installation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "14f5686c-449b-4376-8c58-fc8141f4b0f8",
    "metadata": {},
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0f1d1483-6da7-4372-8390-84c9c280109e",
    "metadata": {},
@@ -18,13 +20,13 @@
     "You can install the *released version* of `HierachicalForecast` from the [Python package index](https://pypi.org) with:\n",
     "\n",
     "```python\n",
-    "pip install hierachicalforecast\n",
+    "pip install hierarchicalforecast\n",
     "```\n",
     "\n",
     "or \n",
     "\n",
     "```python\n",
-    "conda install -c conda-forge hierachicalforecast\n",
+    "conda install -c conda-forge hierarchicalforecast\n",
     "``` \n",
     "\n",
     ":::{.callout-tip}\n",


### PR DESCRIPTION
Changed instructions from `hierachicalforecast` to `hierarchicalforecast`