### PR TITLE
fix: ensure levels are sorted prior to adjacency matrix construction

### DIFF
--- a/hierarchicalforecast/utils.py
+++ b/hierarchicalforecast/utils.py
@@ -64,7 +64,7 @@ def _construct_adjacency_matrix(
 
     """
     # Get the nodes in each level.
-    l = list(tags.values())
+    l = sorted(tags.values(), key=lambda x: len(x))
     # Get the number of aggregation nodes.
     n_a = S.shape[0] - S.shape[1]
     # Copy and cast the summing matrix to bool.

--- a/nbs/src/utils.ipynb
+++ b/nbs/src/utils.ipynb
@@ -59,16 +59,7 @@
    "execution_count": null,
    "id": "3a501424-ebfd-403c-982e-280cb859bd0f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/christopher/miniconda3/envs/hierarchicalforecast/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "from nbdev.showdoc import show_doc\n",
@@ -141,7 +132,7 @@
     "\n",
     "    \"\"\"\n",
     "    # Get the nodes in each level.\n",
-    "    l = list(tags.values())\n",
+    "    l = sorted(tags.values(), key=lambda x: len(x))\n",
     "    # Get the number of aggregation nodes.\n",
     "    n_a = S.shape[0] - S.shape[1]\n",
     "    # Copy and cast the summing matrix to bool.\n",


### PR DESCRIPTION
This PR closes #343 by sorting the values in `tags` in `_construct_adjacency_matrix` prior to constructing the adjacency matrix.