### PR TITLE
[BUG] Remove y requirement from reconcile

### DIFF
--- a/hierarchicalforecast/core.py
+++ b/hierarchicalforecast/core.py
@@ -149,9 +149,9 @@ class HierarchicalReconciliation:
                     f"Temporal reconciliation is not supported for intervals_method=`{intervals_method}`."
                 )
 
-            missing_cols_temporal = set(
-                [id_col, time_col, target_col, id_time_col]
-            ) - set(Y_hat_nw_cols)
+            missing_cols_temporal = set([id_col, time_col, id_time_col]) - set(
+                Y_hat_nw_cols
+            )
             if missing_cols_temporal:
                 raise ValueError(
                     f"Check `Y_hat_df` columns, for temporal reconciliation {reprlib.repr(missing_cols_temporal)} must be in `Y_hat_df` columns."

--- a/nbs/src/core.ipynb
+++ b/nbs/src/core.ipynb
@@ -247,7 +247,7 @@
     "            if intervals_method in ['bootstrap', 'permbu']:\n",
     "                raise NotImplementedError(f\"Temporal reconciliation is not supported for intervals_method=`{intervals_method}`.\")            \n",
     "            \n",
-    "            missing_cols_temporal = set([id_col, time_col, target_col, id_time_col]) - set(Y_hat_nw_cols)\n",
+    "            missing_cols_temporal = set([id_col, time_col, id_time_col]) - set(Y_hat_nw_cols)\n",
     "            if missing_cols_temporal:\n",
     "                raise ValueError(f\"Check `Y_hat_df` columns, for temporal reconciliation {reprlib.repr(missing_cols_temporal)} must be in `Y_hat_df` columns.\")\n",
     "            if id_time_col not in S_nw_cols:\n",


### PR DESCRIPTION
When checking `Y_hat` for missing cols during temporal reconcilation, we require `target_col` to be present, which shouldn't be the case (normally it's absent as it's unknown during prediction)