### PR TITLE
[FIX] Add utilsforecast to dependencies

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 2
-requirements = numpy, numba, pandas>=2.1.0, scikit-learn>=1.2, quadprog, clarabel, matplotlib, narwhals>=1.27.0, intel-cmplr-lib-rt ; platform_system!="Darwin" and platform_machine=="x86_64"
+requirements = numpy, numba, pandas>=2.1.0, scikit-learn>=1.2, quadprog, clarabel, matplotlib, narwhals>=1.27.0, utilsforecast>=0.2.12, intel-cmplr-lib-rt ; platform_system!="Darwin" and platform_machine=="x86_64"
 dev_requirements = datasetsforecast ipython<=8.32.0 nbdev statsforecast>=1.0.0 requests scipy pre-commit ruff black pytest pytest-benchmark
 polars_requirements = polars[numpy]
 nbs_path = nbs


### PR DESCRIPTION
Utilsforecast should be part of HF's dependencies, as statsforecast may not always be jointly installed (#365).