### PR TITLE
[FIX] TopDown with "forecast_proportions" should error when providing a non-strict hierarchy.

### DIFF
--- a/nbs/src/methods.ipynb
+++ b/nbs/src/methods.ipynb
@@ -381,7 +381,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\ospra\\miniconda3\\envs\\hierarchicalforecast\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L163){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp\n",
+       "\n",
+       ">      BottomUp ()\n",
+       "\n",
+       "*Bottom Up Reconciliation Class.\n",
+       "The most basic hierarchical reconciliation is performed using an Bottom-Up strategy. It was proposed for\n",
+       "the first time by Orcutt in 1968.\n",
+       "The corresponding hierarchical \"projection\" matrix is defined as:\n",
+       "$$\\mathbf{P}_{\\text{BU}} = [\\mathbf{0}_{\\mathrm{[b],[a]}}\\;|\\;\\mathbf{I}_{\\mathrm{[b][b]}}]$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "None\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Orcutt, G.H., Watts, H.W., & Edwards, J.B.(1968). \"Data aggregation and information loss\". The American\n",
+       "Economic Review, 58 , 773(787)](http://www.jstor.org/stable/1815532).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L163){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp\n",
+       "\n",
+       ">      BottomUp ()\n",
+       "\n",
+       "*Bottom Up Reconciliation Class.\n",
+       "The most basic hierarchical reconciliation is performed using an Bottom-Up strategy. It was proposed for\n",
+       "the first time by Orcutt in 1968.\n",
+       "The corresponding hierarchical \"projection\" matrix is defined as:\n",
+       "$$\\mathbf{P}_{\\text{BU}} = [\\mathbf{0}_{\\mathrm{[b],[a]}}\\;|\\;\\mathbf{I}_{\\mathrm{[b][b]}}]$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "None\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Orcutt, G.H., Watts, H.W., & Edwards, J.B.(1968). \"Data aggregation and information loss\". The American\n",
+       "Economic Review, 58 , 773(787)](http://www.jstor.org/stable/1815532).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUp, title_level=3)"
    ]
@@ -390,7 +450,81 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.fit\n",
+       "\n",
+       ">      BottomUp.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                    idx_bottom:numpy.ndarray,\n",
+       ">                    y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                    intervals_method:Optional[str]=None,\n",
+       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                    tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*Bottom Up Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.fit\n",
+       "\n",
+       ">      BottomUp.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                    idx_bottom:numpy.ndarray,\n",
+       ">                    y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                    intervals_method:Optional[str]=None,\n",
+       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                    tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*Bottom Up Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUp.fit, name=\"BottomUp.fit\", title_level=3)"
    ]
@@ -399,7 +533,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.predict\n",
+       "\n",
+       ">      BottomUp.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                        level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.predict\n",
+       "\n",
+       ">      BottomUp.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                        level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUp.predict, name=\"BottomUp.predict\", title_level=3)"
    ]
@@ -408,7 +594,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.fit_predict\n",
+       "\n",
+       ">      BottomUp.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                            idx_bottom:numpy.ndarray,\n",
+       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                            level:Optional[list[int]]=None,\n",
+       ">                            intervals_method:Optional[str]=None,\n",
+       ">                            num_samples:Optional[int]=None,\n",
+       ">                            seed:Optional[int]=None,\n",
+       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*BottomUp Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.fit_predict\n",
+       "\n",
+       ">      BottomUp.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                            idx_bottom:numpy.ndarray,\n",
+       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                            level:Optional[list[int]]=None,\n",
+       ">                            intervals_method:Optional[str]=None,\n",
+       ">                            num_samples:Optional[int]=None,\n",
+       ">                            seed:Optional[int]=None,\n",
+       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*BottomUp Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUp.fit_predict, name=\"BottomUp.fit_predict\", title_level=3)"
    ]
@@ -417,7 +683,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.sample\n",
+       "\n",
+       ">      BottomUp.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUp.sample\n",
+       "\n",
+       ">      BottomUp.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUp.sample, name=\"BottomUp.sample\", title_level=3)"
    ]
@@ -457,7 +775,53 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L290){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse\n",
+       "\n",
+       ">      BottomUpSparse ()\n",
+       "\n",
+       "*BottomUpSparse Reconciliation Class.\n",
+       "\n",
+       "This is the implementation of a Bottom Up reconciliation using the sparse\n",
+       "matrix approach. It works much more efficient on datasets with many time series.\n",
+       "[makoren: At least I hope so, I only checked up until ~20k time series, and\n",
+       "there's no real improvement, it would be great to check for smth like 1M time\n",
+       "series, where the dense S matrix really stops fitting in memory]\n",
+       "\n",
+       "See the parent class for more details.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L290){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse\n",
+       "\n",
+       ">      BottomUpSparse ()\n",
+       "\n",
+       "*BottomUpSparse Reconciliation Class.\n",
+       "\n",
+       "This is the implementation of a Bottom Up reconciliation using the sparse\n",
+       "matrix approach. It works much more efficient on datasets with many time series.\n",
+       "[makoren: At least I hope so, I only checked up until ~20k time series, and\n",
+       "there's no real improvement, it would be great to check for smth like 1M time\n",
+       "series, where the dense S matrix really stops fitting in memory]\n",
+       "\n",
+       "See the parent class for more details.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUpSparse, title_level=3)"
    ]
@@ -466,7 +830,83 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.fit\n",
+       "\n",
+       ">      BottomUpSparse.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                          idx_bottom:numpy.ndarray,\n",
+       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                          intervals_method:Optional[str]=None,\n",
+       ">                          num_samples:Optional[int]=None,\n",
+       ">                          seed:Optional[int]=None,\n",
+       ">                          tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*Bottom Up Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.fit\n",
+       "\n",
+       ">      BottomUpSparse.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                          idx_bottom:numpy.ndarray,\n",
+       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                          intervals_method:Optional[str]=None,\n",
+       ">                          num_samples:Optional[int]=None,\n",
+       ">                          seed:Optional[int]=None,\n",
+       ">                          tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*Bottom Up Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUpSparse.fit, name=\"BottomUpSparse.fit\", title_level=3)"
    ]
@@ -475,7 +915,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.predict\n",
+       "\n",
+       ">      BottomUpSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                              level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.predict\n",
+       "\n",
+       ">      BottomUpSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                              level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUpSparse.predict, name=\"BottomUpSparse.predict\", title_level=3)"
    ]
@@ -484,7 +976,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.fit_predict\n",
+       "\n",
+       ">      BottomUpSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  idx_bottom:numpy.ndarray,\n",
+       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                  level:Optional[list[int]]=None,\n",
+       ">                                  intervals_method:Optional[str]=None,\n",
+       ">                                  num_samples:Optional[int]=None,\n",
+       ">                                  seed:Optional[int]=None,\n",
+       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*BottomUp Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.fit_predict\n",
+       "\n",
+       ">      BottomUpSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  idx_bottom:numpy.ndarray,\n",
+       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                  level:Optional[list[int]]=None,\n",
+       ">                                  intervals_method:Optional[str]=None,\n",
+       ">                                  num_samples:Optional[int]=None,\n",
+       ">                                  seed:Optional[int]=None,\n",
+       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*BottomUp Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUpSparse.fit_predict, name=\"BottomUpSparse.fit_predict\", title_level=3)"
    ]
@@ -493,7 +1065,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.sample\n",
+       "\n",
+       ">      BottomUpSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### BottomUpSparse.sample\n",
+       "\n",
+       ">      BottomUpSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(BottomUpSparse.sample, name=\"BottomUpSparse.sample\", title_level=3)"
    ]
@@ -753,6 +1377,8 @@
     "    doi:10.1016/S0305-0548(99)00017-9](https://doi.org/10.1016/S0305-0548(99)00017-9).\n",
     "    \"\"\"\n",
     "\n",
+    "    is_strictly_hierarchical = False\n",
+    "\n",
     "    def __init__(self, method: str):\n",
     "        if method not in [\"forecast_proportions\", \"average_proportions\", \"proportion_averages\"]:\n",
     "            raise ValueError(\n",
@@ -894,6 +1520,12 @@
     "        `y_tilde`: Reconciliated y_hat using the Top Down approach.\n",
     "        \"\"\"\n",
     "        if self.method == \"forecast_proportions\":\n",
+    "            if not self.is_strictly_hierarchical:\n",
+    "                # Check if the data structure is strictly hierarchical.\n",
+    "                if tags is not None and not is_strictly_hierarchical(S, tags):\n",
+    "                    raise ValueError(\n",
+    "                        \"Top-down reconciliation requires strictly hierarchical structures.\"\n",
+    "                    )\n",
     "            S_sum = np.sum(S, axis=1)\n",
     "            if S.shape[1] > 1:\n",
     "                S_max_idxs = np.argsort(S_sum)[::-1]\n",
@@ -941,7 +1573,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L363){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown\n",
+       "\n",
+       ">      TopDown (method:str)\n",
+       "\n",
+       "*Top Down Reconciliation Class.\n",
+       "\n",
+       "The Top Down hierarchical reconciliation method, distributes the total aggregate predictions and decomposes\n",
+       "it down the hierarchy using proportions $\\mathbf{p}_{\\mathrm{[b]}}$ that can be actual historical values\n",
+       "or estimated.\n",
+       "\n",
+       "$$\\mathbf{P}=[\\mathbf{p}_{\\mathrm{[b]}}\\;|\\;\\mathbf{0}_{\\mathrm{[b][a,b\\;-1]}}]$$\n",
+       "**Parameters:**<br>\n",
+       "`method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [CW. Gross (1990). \"Disaggregation methods to expedite product line forecasting\". Journal of Forecasting, 9 , 233–254.\n",
+       "doi:10.1002/for.3980090304](https://onlinelibrary.wiley.com/doi/abs/10.1002/for.3980090304).<br>\n",
+       "- [G. Fliedner (1999). \"An investigation of aggregate variable time series forecast strategies with specific subaggregate\n",
+       "time series statistical correlation\". Computers and Operations Research, 26 , 1133–1149.\n",
+       "doi:10.1016/S0305-0548(99)00017-9](https://doi.org/10.1016/S0305-0548(99)00017-9).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L363){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown\n",
+       "\n",
+       ">      TopDown (method:str)\n",
+       "\n",
+       "*Top Down Reconciliation Class.\n",
+       "\n",
+       "The Top Down hierarchical reconciliation method, distributes the total aggregate predictions and decomposes\n",
+       "it down the hierarchy using proportions $\\mathbf{p}_{\\mathrm{[b]}}$ that can be actual historical values\n",
+       "or estimated.\n",
+       "\n",
+       "$$\\mathbf{P}=[\\mathbf{p}_{\\mathrm{[b]}}\\;|\\;\\mathbf{0}_{\\mathrm{[b][a,b\\;-1]}}]$$\n",
+       "**Parameters:**<br>\n",
+       "`method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [CW. Gross (1990). \"Disaggregation methods to expedite product line forecasting\". Journal of Forecasting, 9 , 233–254.\n",
+       "doi:10.1002/for.3980090304](https://onlinelibrary.wiley.com/doi/abs/10.1002/for.3980090304).<br>\n",
+       "- [G. Fliedner (1999). \"An investigation of aggregate variable time series forecast strategies with specific subaggregate\n",
+       "time series statistical correlation\". Computers and Operations Research, 26 , 1133–1149.\n",
+       "doi:10.1016/S0305-0548(99)00017-9](https://doi.org/10.1016/S0305-0548(99)00017-9).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDown, title_level=3)"
    ]
@@ -950,7 +1642,79 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.fit\n",
+       "\n",
+       ">      TopDown.fit (S, y_hat, y_insample:numpy.ndarray,\n",
+       ">                   y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                   sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                   intervals_method:Optional[str]=None,\n",
+       ">                   num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                   tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                   idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*TopDown Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.fit\n",
+       "\n",
+       ">      TopDown.fit (S, y_hat, y_insample:numpy.ndarray,\n",
+       ">                   y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                   sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                   intervals_method:Optional[str]=None,\n",
+       ">                   num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                   tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                   idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*TopDown Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDown.fit, name=\"TopDown.fit\", title_level=3)"
    ]
@@ -959,7 +1723,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.predict\n",
+       "\n",
+       ">      TopDown.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                       level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.predict\n",
+       "\n",
+       ">      TopDown.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                       level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDown.predict, name=\"TopDown.predict\", title_level=3)"
    ]
@@ -968,7 +1784,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L496){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.fit_predict\n",
+       "\n",
+       ">      TopDown.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                           tags:dict[str,numpy.ndarray],\n",
+       ">                           idx_bottom:numpy.ndarray=None,\n",
+       ">                           y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                           y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                           sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                           level:Optional[list[int]]=None,\n",
+       ">                           intervals_method:Optional[str]=None,\n",
+       ">                           num_samples:Optional[int]=None,\n",
+       ">                           seed:Optional[int]=None)\n",
+       "\n",
+       "*Top Down Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L496){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.fit_predict\n",
+       "\n",
+       ">      TopDown.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                           tags:dict[str,numpy.ndarray],\n",
+       ">                           idx_bottom:numpy.ndarray=None,\n",
+       ">                           y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                           y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                           sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                           level:Optional[list[int]]=None,\n",
+       ">                           intervals_method:Optional[str]=None,\n",
+       ">                           num_samples:Optional[int]=None,\n",
+       ">                           seed:Optional[int]=None)\n",
+       "\n",
+       "*Top Down Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDown.fit_predict, name=\"TopDown.fit_predict\", title_level=3)"
    ]
@@ -977,7 +1873,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.sample\n",
+       "\n",
+       ">      TopDown.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDown.sample\n",
+       "\n",
+       ">      TopDown.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDown.sample, name=\"TopDown.sample\", title_level=3)"
    ]
@@ -1140,7 +2088,47 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L574){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse\n",
+       "\n",
+       ">      TopDownSparse (method:str)\n",
+       "\n",
+       "*TopDownSparse Reconciliation Class.\n",
+       "\n",
+       "This is an implementation of top-down reconciliation using the sparse matrix\n",
+       "approach. It works much more efficiently on data sets with many time series.\n",
+       "\n",
+       "See the parent class for more details.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L574){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse\n",
+       "\n",
+       ">      TopDownSparse (method:str)\n",
+       "\n",
+       "*TopDownSparse Reconciliation Class.\n",
+       "\n",
+       "This is an implementation of top-down reconciliation using the sparse matrix\n",
+       "approach. It works much more efficiently on data sets with many time series.\n",
+       "\n",
+       "See the parent class for more details.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDownSparse, title_level=3)"
    ]
@@ -1149,7 +2137,81 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.fit\n",
+       "\n",
+       ">      TopDownSparse.fit (S, y_hat, y_insample:numpy.ndarray,\n",
+       ">                         y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                         sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                         intervals_method:Optional[str]=None,\n",
+       ">                         num_samples:Optional[int]=None,\n",
+       ">                         seed:Optional[int]=None,\n",
+       ">                         tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                         idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*TopDown Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.fit\n",
+       "\n",
+       ">      TopDownSparse.fit (S, y_hat, y_insample:numpy.ndarray,\n",
+       ">                         y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                         sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                         intervals_method:Optional[str]=None,\n",
+       ">                         num_samples:Optional[int]=None,\n",
+       ">                         seed:Optional[int]=None,\n",
+       ">                         tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                         idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*TopDown Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDownSparse.fit, name=\"TopDownSparse.fit\", title_level=3)"
    ]
@@ -1158,7 +2220,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.predict\n",
+       "\n",
+       ">      TopDownSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                             level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.predict\n",
+       "\n",
+       ">      TopDownSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                             level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDownSparse.predict, name=\"TopDownSparse.predict\", title_level=3)"
    ]
@@ -1167,7 +2281,89 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L640){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.fit_predict\n",
+       "\n",
+       ">      TopDownSparse.fit_predict (S:scipy.sparse._csr.csr_matrix,\n",
+       ">                                 y_hat:numpy.ndarray,\n",
+       ">                                 tags:dict[str,numpy.ndarray],\n",
+       ">                                 idx_bottom:numpy.ndarray=None,\n",
+       ">                                 y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                 y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                 sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                 level:Optional[list[int]]=None,\n",
+       ">                                 intervals_method:Optional[str]=None,\n",
+       ">                                 num_samples:Optional[int]=None,\n",
+       ">                                 seed:Optional[int]=None)\n",
+       "\n",
+       "*Top Down Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L640){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.fit_predict\n",
+       "\n",
+       ">      TopDownSparse.fit_predict (S:scipy.sparse._csr.csr_matrix,\n",
+       ">                                 y_hat:numpy.ndarray,\n",
+       ">                                 tags:dict[str,numpy.ndarray],\n",
+       ">                                 idx_bottom:numpy.ndarray=None,\n",
+       ">                                 y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                 y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                 sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                 level:Optional[list[int]]=None,\n",
+       ">                                 intervals_method:Optional[str]=None,\n",
+       ">                                 num_samples:Optional[int]=None,\n",
+       ">                                 seed:Optional[int]=None)\n",
+       "\n",
+       "*Top Down Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDownSparse.fit_predict, name=\"TopDownSparse.fit_predict\", title_level=3)"
    ]
@@ -1176,7 +2372,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.sample\n",
+       "\n",
+       ">      TopDownSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### TopDownSparse.sample\n",
+       "\n",
+       ">      TopDownSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TopDownSparse.sample, name=\"TopDownSparse.sample\", title_level=3)"
    ]
@@ -1215,7 +2463,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[10., 10.],\n",
+       "       [ 3.,  3.],\n",
+       "       [ 7.,  7.],\n",
+       "       [ 1.,  1.],\n",
+       "       [ 2.,  2.],\n",
+       "       [ 3.,  3.],\n",
+       "       [ 4.,  4.]])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "cls_top_down(\n",
     "                S=S, y_hat=S @ y_hat_bottom, y_insample=S @ y_bottom, tags=tags\n",
@@ -1451,6 +2716,9 @@
     "                        complete_idxs_child.append(idxs_child)\n",
     "                parents[idx_middle_out][lv_child] = np.hstack(complete_idxs_child)\n",
     "\n",
+    "        cls_top_down = TopDown(self.top_down_method)\n",
+    "        cls_top_down.is_strictly_hierarchical = True\n",
+    "\n",
     "        for node, levels_node in parents.items():\n",
     "            idxs_node = np.hstack(list(levels_node.values()))\n",
     "            S_node = S[idxs_node]\n",
@@ -1461,7 +2729,7 @@
     "                idxs_len = len(idxs_level)\n",
     "                levels_node_[lv_name] = np.arange(counter, idxs_len + counter)\n",
     "                counter += idxs_len\n",
-    "            td = TopDown(self.top_down_method).fit_predict(\n",
+    "            td = cls_top_down.fit_predict(\n",
     "                S=S_node,\n",
     "                y_hat=y_hat[idxs_node],\n",
     "                y_insample=y_insample[idxs_node] if y_insample is not None else None,\n",
@@ -1477,7 +2745,63 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L721){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut\n",
+       "\n",
+       ">      MiddleOut (middle_level:str, top_down_method:str)\n",
+       "\n",
+       "*Middle Out Reconciliation Class.\n",
+       "\n",
+       "This method is only available for **strictly hierarchical structures**. It anchors the base predictions\n",
+       "in a middle level. The levels above the base predictions use the Bottom-Up approach, while the levels\n",
+       "below use a Top-Down.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`middle_level`: Middle level.<br>\n",
+       "`top_down_method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Hyndman, R.J., & Athanasopoulos, G. (2021). \"Forecasting: principles and practice, 3rd edition:\n",
+       "Chapter 11: Forecasting hierarchical and grouped series.\". OTexts: Melbourne, Australia. OTexts.com/fpp3\n",
+       "Accessed on July 2022.](https://otexts.com/fpp3/hierarchical.html)*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L721){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut\n",
+       "\n",
+       ">      MiddleOut (middle_level:str, top_down_method:str)\n",
+       "\n",
+       "*Middle Out Reconciliation Class.\n",
+       "\n",
+       "This method is only available for **strictly hierarchical structures**. It anchors the base predictions\n",
+       "in a middle level. The levels above the base predictions use the Bottom-Up approach, while the levels\n",
+       "below use a Top-Down.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`middle_level`: Middle level.<br>\n",
+       "`top_down_method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Hyndman, R.J., & Athanasopoulos, G. (2021). \"Forecasting: principles and practice, 3rd edition:\n",
+       "Chapter 11: Forecasting hierarchical and grouped series.\". OTexts: Melbourne, Australia. OTexts.com/fpp3\n",
+       "Accessed on July 2022.](https://otexts.com/fpp3/hierarchical.html)*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOut, title_level=3)"
    ]
@@ -1486,7 +2810,33 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.fit\n",
+       "\n",
+       ">      MiddleOut.fit (**kwargs)"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.fit\n",
+       "\n",
+       ">      MiddleOut.fit (**kwargs)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOut.fit, name=\"MiddleOut.fit\", title_level=3)"
    ]
@@ -1495,7 +2845,57 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.predict\n",
+       "\n",
+       ">      MiddleOut.predict (**kwargs)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.predict\n",
+       "\n",
+       ">      MiddleOut.predict (**kwargs)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOut.predict, name=\"MiddleOut.predict\", title_level=3)"
    ]
@@ -1504,7 +2904,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L764){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.fit_predict\n",
+       "\n",
+       ">      MiddleOut.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                             tags:dict[str,numpy.ndarray],\n",
+       ">                             y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                             level:Optional[list[int]]=None,\n",
+       ">                             intervals_method:Optional[str]=None)\n",
+       "\n",
+       "*Middle Out Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
+       "`level`: Not supported. <br>\n",
+       "`intervals_method`: Not supported.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L764){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.fit_predict\n",
+       "\n",
+       ">      MiddleOut.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                             tags:dict[str,numpy.ndarray],\n",
+       ">                             y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                             level:Optional[list[int]]=None,\n",
+       ">                             intervals_method:Optional[str]=None)\n",
+       "\n",
+       "*Middle Out Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
+       "`level`: Not supported. <br>\n",
+       "`intervals_method`: Not supported.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOut.fit_predict, title_level=3)"
    ]
@@ -1513,7 +2973,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.sample\n",
+       "\n",
+       ">      MiddleOut.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOut.sample\n",
+       "\n",
+       ">      MiddleOut.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOut.sample, name=\"MiddleOut.sample\", title_level=3)"
    ]
@@ -1631,7 +3143,47 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L858){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse\n",
+       "\n",
+       ">      MiddleOutSparse (middle_level:str, top_down_method:str)\n",
+       "\n",
+       "*MiddleOutSparse Reconciliation Class.\n",
+       "\n",
+       "This is an implementation of middle-out reconciliation using the sparse matrix\n",
+       "approach. It works much more efficiently on data sets with many time series.\n",
+       "\n",
+       "See the parent class for more details.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L858){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse\n",
+       "\n",
+       ">      MiddleOutSparse (middle_level:str, top_down_method:str)\n",
+       "\n",
+       "*MiddleOutSparse Reconciliation Class.\n",
+       "\n",
+       "This is an implementation of middle-out reconciliation using the sparse matrix\n",
+       "approach. It works much more efficiently on data sets with many time series.\n",
+       "\n",
+       "See the parent class for more details.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOutSparse, title_level=3)"
    ]
@@ -1640,7 +3192,33 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.fit\n",
+       "\n",
+       ">      MiddleOutSparse.fit (**kwargs)"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.fit\n",
+       "\n",
+       ">      MiddleOutSparse.fit (**kwargs)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOutSparse.fit, name=\"MiddleOutSparse.fit\", title_level=3)"
    ]
@@ -1649,7 +3227,57 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.predict\n",
+       "\n",
+       ">      MiddleOutSparse.predict (**kwargs)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.predict\n",
+       "\n",
+       ">      MiddleOutSparse.predict (**kwargs)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOutSparse.predict, name=\"MiddleOutSparse.predict\", title_level=3)"
    ]
@@ -1658,7 +3286,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L873){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.fit_predict\n",
+       "\n",
+       ">      MiddleOutSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                   tags:dict[str,numpy.ndarray],\n",
+       ">                                   y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                   level:Optional[list[int]]=None,\n",
+       ">                                   intervals_method:Optional[str]=None)\n",
+       "\n",
+       "*Middle Out Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
+       "`level`: Not supported. <br>\n",
+       "`intervals_method`: Not supported.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L873){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.fit_predict\n",
+       "\n",
+       ">      MiddleOutSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                   tags:dict[str,numpy.ndarray],\n",
+       ">                                   y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                   level:Optional[list[int]]=None,\n",
+       ">                                   intervals_method:Optional[str]=None)\n",
+       "\n",
+       "*Middle Out Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
+       "`level`: Not supported. <br>\n",
+       "`intervals_method`: Not supported.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOutSparse.fit_predict, title_level=3)"
    ]
@@ -1667,7 +3355,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.sample\n",
+       "\n",
+       ">      MiddleOutSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MiddleOutSparse.sample\n",
+       "\n",
+       ">      MiddleOutSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MiddleOutSparse.sample, name=\"MiddleOutSparse.sample\", title_level=3)"
    ]
@@ -2105,7 +3845,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L960){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace\n",
+       "\n",
+       ">      MinTrace (method:str, nonnegative:bool=False,\n",
+       ">                mint_shr_ridge:Optional[float]=2e-08, num_threads:int=1)\n",
+       "\n",
+       "*MinTrace Reconciliation Class.\n",
+       "\n",
+       "This reconciliation algorithm proposed by Wickramasuriya et al. depends on a generalized least squares estimator\n",
+       "and an estimator of the covariance matrix of the coherency errors $\\mathbf{W}_{h}$. The Min Trace algorithm\n",
+       "minimizes the squared errors for the coherent forecasts under an unbiasedness assumption; the solution has a\n",
+       "closed form.<br>\n",
+       "\n",
+       "$$\n",
+       "\\mathbf{P}_{\\text{MinT}}=\\left(\\mathbf{S}^{\\intercal}\\mathbf{W}_{h}\\mathbf{S}\\right)^{-1}\n",
+       "\\mathbf{S}^{\\intercal}\\mathbf{W}^{-1}_{h}\n",
+       "$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `ols`, `wls_struct`, `wls_var`, `mint_shrink`, `mint_cov`.<br>\n",
+       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
+       "`mint_shr_ridge`: float=2e-8, ridge numeric protection to MinTrace-shr covariance estimator.<br>\n",
+       "`num_threads`: int=1, number of threads to use for solving the optimization problems (when nonnegative=True).\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Wickramasuriya, S. L., Athanasopoulos, G., & Hyndman, R. J. (2019). \"Optimal forecast reconciliation for\n",
+       "hierarchical and grouped time series through trace minimization\". Journal of the American Statistical Association,\n",
+       "114 , 804–819. doi:10.1080/01621459.2018.1448825.](https://robjhyndman.com/publications/mint/).\n",
+       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
+       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
+       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L960){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace\n",
+       "\n",
+       ">      MinTrace (method:str, nonnegative:bool=False,\n",
+       ">                mint_shr_ridge:Optional[float]=2e-08, num_threads:int=1)\n",
+       "\n",
+       "*MinTrace Reconciliation Class.\n",
+       "\n",
+       "This reconciliation algorithm proposed by Wickramasuriya et al. depends on a generalized least squares estimator\n",
+       "and an estimator of the covariance matrix of the coherency errors $\\mathbf{W}_{h}$. The Min Trace algorithm\n",
+       "minimizes the squared errors for the coherent forecasts under an unbiasedness assumption; the solution has a\n",
+       "closed form.<br>\n",
+       "\n",
+       "$$\n",
+       "\\mathbf{P}_{\\text{MinT}}=\\left(\\mathbf{S}^{\\intercal}\\mathbf{W}_{h}\\mathbf{S}\\right)^{-1}\n",
+       "\\mathbf{S}^{\\intercal}\\mathbf{W}^{-1}_{h}\n",
+       "$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `ols`, `wls_struct`, `wls_var`, `mint_shrink`, `mint_cov`.<br>\n",
+       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
+       "`mint_shr_ridge`: float=2e-8, ridge numeric protection to MinTrace-shr covariance estimator.<br>\n",
+       "`num_threads`: int=1, number of threads to use for solving the optimization problems (when nonnegative=True).\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Wickramasuriya, S. L., Athanasopoulos, G., & Hyndman, R. J. (2019). \"Optimal forecast reconciliation for\n",
+       "hierarchical and grouped time series through trace minimization\". Journal of the American Statistical Association,\n",
+       "114 , 804–819. doi:10.1080/01621459.2018.1448825.](https://robjhyndman.com/publications/mint/).\n",
+       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
+       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
+       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTrace, title_level=3)"
    ]
@@ -2114,7 +3934,79 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.fit\n",
+       "\n",
+       ">      MinTrace.fit (S, y_hat, y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                    intervals_method:Optional[str]=None,\n",
+       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                    tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                    idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTrace Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.fit\n",
+       "\n",
+       ">      MinTrace.fit (S, y_hat, y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                    intervals_method:Optional[str]=None,\n",
+       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                    tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                    idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTrace Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTrace.fit, name=\"MinTrace.fit\", title_level=3)"
    ]
@@ -2123,7 +4015,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.predict\n",
+       "\n",
+       ">      MinTrace.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                        level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.predict\n",
+       "\n",
+       ">      MinTrace.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                        level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTrace.predict, name=\"MinTrace.predict\", title_level=3)"
    ]
@@ -2132,7 +4076,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.fit_predict\n",
+       "\n",
+       ">      MinTrace.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                            idx_bottom:numpy.ndarray=None,\n",
+       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                            level:Optional[list[int]]=None,\n",
+       ">                            intervals_method:Optional[str]=None,\n",
+       ">                            num_samples:Optional[int]=None,\n",
+       ">                            seed:Optional[int]=None,\n",
+       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.fit_predict\n",
+       "\n",
+       ">      MinTrace.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                            idx_bottom:numpy.ndarray=None,\n",
+       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                            level:Optional[list[int]]=None,\n",
+       ">                            intervals_method:Optional[str]=None,\n",
+       ">                            num_samples:Optional[int]=None,\n",
+       ">                            seed:Optional[int]=None,\n",
+       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTrace.fit_predict, name=\"MinTrace.fit_predict\", title_level=3)"
    ]
@@ -2141,7 +4165,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.sample\n",
+       "\n",
+       ">      MinTrace.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTrace.sample\n",
+       "\n",
+       ">      MinTrace.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTrace.sample, name=\"MinTrace.sample\", title_level=3)"
    ]
@@ -2482,7 +4558,65 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1280){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse\n",
+       "\n",
+       ">      MinTraceSparse (method:str, nonnegative:bool=False, num_threads:int=1,\n",
+       ">                      qp:bool=True)\n",
+       "\n",
+       "*MinTraceSparse Reconciliation Class.\n",
+       "\n",
+       "This is the implementation of OLS and WLS estimators using sparse matrices. It is not guaranteed\n",
+       "to give identical results to the non-sparse version, but works much more efficiently on data sets\n",
+       "with many time series.<br>\n",
+       "\n",
+       "See the parent class for more details.<br>\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `ols`, `wls_struct`, or `wls_var`.<br>\n",
+       "`nonnegative`: bool, return non-negative reconciled forecasts.<br>\n",
+       "`num_threads`: int, number of threads to execute non-negative quadratic programming calls.<br>\n",
+       "`qp`: bool, implement non-negativity constraint with a quadratic programming approach. Setting \n",
+       "this to True generally gives better results, but at the expense of higher cost to compute. <br>*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1280){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse\n",
+       "\n",
+       ">      MinTraceSparse (method:str, nonnegative:bool=False, num_threads:int=1,\n",
+       ">                      qp:bool=True)\n",
+       "\n",
+       "*MinTraceSparse Reconciliation Class.\n",
+       "\n",
+       "This is the implementation of OLS and WLS estimators using sparse matrices. It is not guaranteed\n",
+       "to give identical results to the non-sparse version, but works much more efficiently on data sets\n",
+       "with many time series.<br>\n",
+       "\n",
+       "See the parent class for more details.<br>\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `ols`, `wls_struct`, or `wls_var`.<br>\n",
+       "`nonnegative`: bool, return non-negative reconciled forecasts.<br>\n",
+       "`num_threads`: int, number of threads to execute non-negative quadratic programming calls.<br>\n",
+       "`qp`: bool, implement non-negativity constraint with a quadratic programming approach. Setting \n",
+       "this to True generally gives better results, but at the expense of higher cost to compute. <br>*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTraceSparse, title_level=3)"
    ]
@@ -2491,7 +4625,83 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1401){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.fit\n",
+       "\n",
+       ">      MinTraceSparse.fit (S:scipy.sparse._csr.csr_matrix, y_hat:numpy.ndarray,\n",
+       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                          intervals_method:Optional[str]=None,\n",
+       ">                          num_samples:Optional[int]=None,\n",
+       ">                          seed:Optional[int]=None,\n",
+       ">                          tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                          idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTraceSparse Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1401){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.fit\n",
+       "\n",
+       ">      MinTraceSparse.fit (S:scipy.sparse._csr.csr_matrix, y_hat:numpy.ndarray,\n",
+       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                          intervals_method:Optional[str]=None,\n",
+       ">                          num_samples:Optional[int]=None,\n",
+       ">                          seed:Optional[int]=None,\n",
+       ">                          tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                          idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTraceSparse Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTraceSparse.fit, name=\"MinTraceSparse.fit\", title_level=3)"
    ]
@@ -2500,7 +4710,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.predict\n",
+       "\n",
+       ">      MinTraceSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                              level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.predict\n",
+       "\n",
+       ">      MinTraceSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                              level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTraceSparse.predict, name=\"MinTraceSparse.predict\", title_level=3)"
    ]
@@ -2509,7 +4771,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.fit_predict\n",
+       "\n",
+       ">      MinTraceSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  idx_bottom:numpy.ndarray=None,\n",
+       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                  level:Optional[list[int]]=None,\n",
+       ">                                  intervals_method:Optional[str]=None,\n",
+       ">                                  num_samples:Optional[int]=None,\n",
+       ">                                  seed:Optional[int]=None,\n",
+       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.fit_predict\n",
+       "\n",
+       ">      MinTraceSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  idx_bottom:numpy.ndarray=None,\n",
+       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                  level:Optional[list[int]]=None,\n",
+       ">                                  intervals_method:Optional[str]=None,\n",
+       ">                                  num_samples:Optional[int]=None,\n",
+       ">                                  seed:Optional[int]=None,\n",
+       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTraceSparse.fit_predict, name=\"MinTraceSparse.fit_predict\", title_level=3)"
    ]
@@ -2518,7 +4860,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.sample\n",
+       "\n",
+       ">      MinTraceSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### MinTraceSparse.sample\n",
+       "\n",
+       ">      MinTraceSparse.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(MinTraceSparse.sample, name=\"MinTraceSparse.sample\", title_level=3)"
    ]
@@ -2527,7 +4921,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\ospra\\AppData\\Local\\Temp\\ipykernel_40652\\2921588021.py:48: UserWarning: `num_threads` is only used when `nonnegative=True`\n",
+      "  warnings.warn(\"`num_threads` is only used when `nonnegative=True`\")\n"
+     ]
+    }
+   ],
    "source": [
     "#| hide\n",
     "for method in [\"ols\", \"wls_struct\", \"wls_var\", \"mint_shrink\"]:\n",
@@ -2699,7 +5102,79 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1607){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination\n",
+       "\n",
+       ">      OptimalCombination (method:str, nonnegative:bool=False,\n",
+       ">                          num_threads:int=1)\n",
+       "\n",
+       "*Optimal Combination Reconciliation Class.\n",
+       "\n",
+       "This reconciliation algorithm was proposed by Hyndman et al. 2011, the method uses generalized least squares\n",
+       "estimator using the coherency errors covariance matrix. Consider the covariance of the base forecast\n",
+       "$\\textrm{Var}(\\epsilon_{h}) = \\Sigma_{h}$, the $\\mathbf{P}$ matrix of this method is defined by:\n",
+       "$$ \\mathbf{P} = \\left(\\mathbf{S}^{\\intercal}\\Sigma_{h}^{\\dagger}\\mathbf{S}\\right)^{-1}\\mathbf{S}^{\\intercal}\\Sigma^{\\dagger}_{h}$$\n",
+       "where $\\Sigma_{h}^{\\dagger}$ denotes the variance pseudo-inverse. The method was later proven equivalent to\n",
+       "`MinTrace` variants.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, allowed optimal combination methods: 'ols', 'wls_struct'.<br>\n",
+       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Rob J. Hyndman, Roman A. Ahmed, George Athanasopoulos, Han Lin Shang (2010). \"Optimal Combination Forecasts for\n",
+       "Hierarchical Time Series\".](https://robjhyndman.com/papers/Hierarchical6.pdf).<br>\n",
+       "- [Shanika L. Wickramasuriya, George Athanasopoulos and Rob J. Hyndman (2010). \"Optimal Combination Forecasts for\n",
+       "Hierarchical Time Series\".](https://robjhyndman.com/papers/MinT.pdf).\n",
+       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
+       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
+       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1607){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination\n",
+       "\n",
+       ">      OptimalCombination (method:str, nonnegative:bool=False,\n",
+       ">                          num_threads:int=1)\n",
+       "\n",
+       "*Optimal Combination Reconciliation Class.\n",
+       "\n",
+       "This reconciliation algorithm was proposed by Hyndman et al. 2011, the method uses generalized least squares\n",
+       "estimator using the coherency errors covariance matrix. Consider the covariance of the base forecast\n",
+       "$\\textrm{Var}(\\epsilon_{h}) = \\Sigma_{h}$, the $\\mathbf{P}$ matrix of this method is defined by:\n",
+       "$$ \\mathbf{P} = \\left(\\mathbf{S}^{\\intercal}\\Sigma_{h}^{\\dagger}\\mathbf{S}\\right)^{-1}\\mathbf{S}^{\\intercal}\\Sigma^{\\dagger}_{h}$$\n",
+       "where $\\Sigma_{h}^{\\dagger}$ denotes the variance pseudo-inverse. The method was later proven equivalent to\n",
+       "`MinTrace` variants.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, allowed optimal combination methods: 'ols', 'wls_struct'.<br>\n",
+       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Rob J. Hyndman, Roman A. Ahmed, George Athanasopoulos, Han Lin Shang (2010). \"Optimal Combination Forecasts for\n",
+       "Hierarchical Time Series\".](https://robjhyndman.com/papers/Hierarchical6.pdf).<br>\n",
+       "- [Shanika L. Wickramasuriya, George Athanasopoulos and Rob J. Hyndman (2010). \"Optimal Combination Forecasts for\n",
+       "Hierarchical Time Series\".](https://robjhyndman.com/papers/MinT.pdf).\n",
+       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
+       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
+       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(OptimalCombination, title_level=3)"
    ]
@@ -2708,7 +5183,83 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.fit\n",
+       "\n",
+       ">      OptimalCombination.fit (S, y_hat,\n",
+       ">                              y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                              y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                              sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                              intervals_method:Optional[str]=None,\n",
+       ">                              num_samples:Optional[int]=None,\n",
+       ">                              seed:Optional[int]=None,\n",
+       ">                              tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                              idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTrace Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.fit\n",
+       "\n",
+       ">      OptimalCombination.fit (S, y_hat,\n",
+       ">                              y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                              y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                              sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                              intervals_method:Optional[str]=None,\n",
+       ">                              num_samples:Optional[int]=None,\n",
+       ">                              seed:Optional[int]=None,\n",
+       ">                              tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">                              idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*MinTrace Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
+       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(OptimalCombination.fit, name=\"OptimalCombination.fit\", title_level=3)"
    ]
@@ -2717,7 +5268,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.predict\n",
+       "\n",
+       ">      OptimalCombination.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.predict\n",
+       "\n",
+       ">      OptimalCombination.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                  level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(OptimalCombination.predict, name=\"OptimalCombination.predict\", title_level=3)"
    ]
@@ -2726,7 +5329,87 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.fit_predict\n",
+       "\n",
+       ">      OptimalCombination.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                      idx_bottom:numpy.ndarray=None,\n",
+       ">                                      y_insample:Optional[numpy.ndarray]=None, \n",
+       ">                                      y_hat_insample:Optional[numpy.ndarray]=No\n",
+       ">                                      ne, sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                      level:Optional[list[int]]=None,\n",
+       ">                                      intervals_method:Optional[str]=None,\n",
+       ">                                      num_samples:Optional[int]=None,\n",
+       ">                                      seed:Optional[int]=None, tags:Optional[di\n",
+       ">                                      ct[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.fit_predict\n",
+       "\n",
+       ">      OptimalCombination.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                                      idx_bottom:numpy.ndarray=None,\n",
+       ">                                      y_insample:Optional[numpy.ndarray]=None, \n",
+       ">                                      y_hat_insample:Optional[numpy.ndarray]=No\n",
+       ">                                      ne, sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                                      level:Optional[list[int]]=None,\n",
+       ">                                      intervals_method:Optional[str]=None,\n",
+       ">                                      num_samples:Optional[int]=None,\n",
+       ">                                      seed:Optional[int]=None, tags:Optional[di\n",
+       ">                                      ct[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*MinTrace Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(\n",
     "    OptimalCombination.fit_predict, name=\"OptimalCombination.fit_predict\", title_level=3\n",
@@ -2737,7 +5420,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.sample\n",
+       "\n",
+       ">      OptimalCombination.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### OptimalCombination.sample\n",
+       "\n",
+       ">      OptimalCombination.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(OptimalCombination.sample, name=\"OptimalCombination.sample\", title_level=3)"
    ]
@@ -2782,7 +5517,7 @@
    "source": [
     "#| export\n",
     "class ERM(HReconciler):\n",
-    "    \"\"\"Optimal Combination Reconciliation Class.\n",
+    "    \"\"\"Empirical Risk Minimization Reconciliation Class.\n",
     "\n",
     "    The Empirical Risk Minimization reconciliation strategy relaxes the unbiasedness assumptions from\n",
     "    previous reconciliation methods like MinT and optimizes square errors between the reconciled predictions\n",
@@ -2985,7 +5720,77 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1642){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM\n",
+       "\n",
+       ">      ERM (method:str, lambda_reg:float=0.01)\n",
+       "\n",
+       "*Empirical Risk Minimization Reconciliation Class.\n",
+       "\n",
+       "The Empirical Risk Minimization reconciliation strategy relaxes the unbiasedness assumptions from\n",
+       "previous reconciliation methods like MinT and optimizes square errors between the reconciled predictions\n",
+       "and the validation data to obtain an optimal reconciliation matrix P.\n",
+       "\n",
+       "The exact solution for $\\mathbf{P}$ (`method='closed'`) follows the expression:\n",
+       "$$\\mathbf{P}^{*} = \\left(\\mathbf{S}^{\\intercal}\\mathbf{S}\\right)^{-1}\\mathbf{Y}^{\\intercal}\\hat{\\mathbf{Y}}\\left(\\hat{\\mathbf{Y}}\\hat{\\mathbf{Y}}\\right)^{-1}$$\n",
+       "\n",
+       "The alternative Lasso regularized $\\mathbf{P}$ solution (`method='reg_bu'`) is useful when the observations\n",
+       "of validation data is limited or the exact solution has low numerical stability.\n",
+       "$$\\mathbf{P}^{*} = \\text{argmin}_{\\mathbf{P}} ||\\mathbf{Y}-\\mathbf{S} \\mathbf{P} \\hat{Y} ||^{2}_{2} + \\lambda ||\\mathbf{P}-\\mathbf{P}_{\\text{BU}}||_{1}$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `closed`, `reg` and `reg_bu`.<br>\n",
+       "`lambda_reg`: float, l1 regularizer for `reg` and `reg_bu`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Ben Taieb, S., & Koo, B. (2019). Regularized regression for hierarchical forecasting without\n",
+       "unbiasedness conditions. In Proceedings of the 25th ACM SIGKDD International Conference on Knowledge\n",
+       "Discovery & Data Mining KDD '19 (p. 1337-1347). New York, NY, USA: Association for Computing Machinery.](https://doi.org/10.1145/3292500.3330976).<br>*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1642){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM\n",
+       "\n",
+       ">      ERM (method:str, lambda_reg:float=0.01)\n",
+       "\n",
+       "*Empirical Risk Minimization Reconciliation Class.\n",
+       "\n",
+       "The Empirical Risk Minimization reconciliation strategy relaxes the unbiasedness assumptions from\n",
+       "previous reconciliation methods like MinT and optimizes square errors between the reconciled predictions\n",
+       "and the validation data to obtain an optimal reconciliation matrix P.\n",
+       "\n",
+       "The exact solution for $\\mathbf{P}$ (`method='closed'`) follows the expression:\n",
+       "$$\\mathbf{P}^{*} = \\left(\\mathbf{S}^{\\intercal}\\mathbf{S}\\right)^{-1}\\mathbf{Y}^{\\intercal}\\hat{\\mathbf{Y}}\\left(\\hat{\\mathbf{Y}}\\hat{\\mathbf{Y}}\\right)^{-1}$$\n",
+       "\n",
+       "The alternative Lasso regularized $\\mathbf{P}$ solution (`method='reg_bu'`) is useful when the observations\n",
+       "of validation data is limited or the exact solution has low numerical stability.\n",
+       "$$\\mathbf{P}^{*} = \\text{argmin}_{\\mathbf{P}} ||\\mathbf{Y}-\\mathbf{S} \\mathbf{P} \\hat{Y} ||^{2}_{2} + \\lambda ||\\mathbf{P}-\\mathbf{P}_{\\text{BU}}||_{1}$$\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`method`: str, one of `closed`, `reg` and `reg_bu`.<br>\n",
+       "`lambda_reg`: float, l1 regularizer for `reg` and `reg_bu`.<br>\n",
+       "\n",
+       "**References:**<br>\n",
+       "- [Ben Taieb, S., & Koo, B. (2019). Regularized regression for hierarchical forecasting without\n",
+       "unbiasedness conditions. In Proceedings of the 25th ACM SIGKDD International Conference on Knowledge\n",
+       "Discovery & Data Mining KDD '19 (p. 1337-1347). New York, NY, USA: Association for Computing Machinery.](https://doi.org/10.1145/3292500.3330976).<br>*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(ERM, title_level=3)"
    ]
@@ -2994,7 +5799,77 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1736){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.fit\n",
+       "\n",
+       ">      ERM.fit (S, y_hat, y_insample, y_hat_insample,\n",
+       ">               sigmah:Optional[numpy.ndarray]=None,\n",
+       ">               intervals_method:Optional[str]=None,\n",
+       ">               num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">               tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">               idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*ERM Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1736){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.fit\n",
+       "\n",
+       ">      ERM.fit (S, y_hat, y_insample, y_hat_insample,\n",
+       ">               sigmah:Optional[numpy.ndarray]=None,\n",
+       ">               intervals_method:Optional[str]=None,\n",
+       ">               num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">               tags:Optional[dict[str,numpy.ndarray]]=None,\n",
+       ">               idx_bottom:Optional[numpy.ndarray]=None)\n",
+       "\n",
+       "*ERM Fit Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`self`: object, fitted reconciler.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(ERM.fit, name=\"ERM.fit\", title_level=3)"
    ]
@@ -3003,7 +5878,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.predict\n",
+       "\n",
+       ">      ERM.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                   level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.predict\n",
+       "\n",
+       ">      ERM.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                   level:Optional[list[int]]=None)\n",
+       "\n",
+       "*Predict using reconciler.\n",
+       "\n",
+       "Predict using fitted mean and probabilistic reconcilers.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated predictions.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(ERM.predict, name=\"ERM.predict\", title_level=3)"
    ]
@@ -3012,7 +5939,85 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1789){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.fit_predict\n",
+       "\n",
+       ">      ERM.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                       idx_bottom:numpy.ndarray=None,\n",
+       ">                       y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                       y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                       sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                       level:Optional[list[int]]=None,\n",
+       ">                       intervals_method:Optional[str]=None,\n",
+       ">                       num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                       tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*ERM Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the ERM approach.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1789){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.fit_predict\n",
+       "\n",
+       ">      ERM.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
+       ">                       idx_bottom:numpy.ndarray=None,\n",
+       ">                       y_insample:Optional[numpy.ndarray]=None,\n",
+       ">                       y_hat_insample:Optional[numpy.ndarray]=None,\n",
+       ">                       sigmah:Optional[numpy.ndarray]=None,\n",
+       ">                       level:Optional[list[int]]=None,\n",
+       ">                       intervals_method:Optional[str]=None,\n",
+       ">                       num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
+       ">                       tags:Optional[dict[str,numpy.ndarray]]=None)\n",
+       "\n",
+       "*ERM Reconciliation Method.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
+       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
+       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
+       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
+       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
+       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
+       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
+       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
+       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
+       "`seed`: Seed for reproducibility.<br>\n",
+       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`y_tilde`: Reconciliated y_hat using the ERM approach.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(ERM.fit_predict, name=\"ERM.fit_predict\", title_level=3)"
    ]
@@ -3021,7 +6026,59 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.sample\n",
+       "\n",
+       ">      ERM.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### ERM.sample\n",
+       "\n",
+       ">      ERM.sample (num_samples:int)\n",
+       "\n",
+       "*Sample probabilistic coherent distribution.\n",
+       "\n",
+       "Generates n samples from a probabilistic coherent distribution.\n",
+       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
+       "the `intervals_method` selected during the reconciler's\n",
+       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
+       "\n",
+       "**Parameters:**<br>\n",
+       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
+       "\n",
+       "**Returns:**<br>\n",
+       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(ERM.sample, name=\"ERM.sample\", title_level=3)"
    ]
@@ -3045,15 +6102,6 @@
     "        )[\"mean\"],\n",
     "        S @ y_hat_bottom,\n",
     "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "S @ y_hat_bottom_insample"
    ]
   },
   {
@@ -3240,9 +6288,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hierarchicalforecast",
+   "display_name": "python3",
    "language": "python",
-   "name": "hierarchicalforecast"
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/nbs/src/methods.ipynb
+++ b/nbs/src/methods.ipynb
@@ -381,67 +381,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\ospra\\miniconda3\\envs\\hierarchicalforecast\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L163){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp\n",
-       "\n",
-       ">      BottomUp ()\n",
-       "\n",
-       "*Bottom Up Reconciliation Class.\n",
-       "The most basic hierarchical reconciliation is performed using an Bottom-Up strategy. It was proposed for\n",
-       "the first time by Orcutt in 1968.\n",
-       "The corresponding hierarchical \"projection\" matrix is defined as:\n",
-       "$$\\mathbf{P}_{\\text{BU}} = [\\mathbf{0}_{\\mathrm{[b],[a]}}\\;|\\;\\mathbf{I}_{\\mathrm{[b][b]}}]$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "None\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Orcutt, G.H., Watts, H.W., & Edwards, J.B.(1968). \"Data aggregation and information loss\". The American\n",
-       "Economic Review, 58 , 773(787)](http://www.jstor.org/stable/1815532).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L163){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp\n",
-       "\n",
-       ">      BottomUp ()\n",
-       "\n",
-       "*Bottom Up Reconciliation Class.\n",
-       "The most basic hierarchical reconciliation is performed using an Bottom-Up strategy. It was proposed for\n",
-       "the first time by Orcutt in 1968.\n",
-       "The corresponding hierarchical \"projection\" matrix is defined as:\n",
-       "$$\\mathbf{P}_{\\text{BU}} = [\\mathbf{0}_{\\mathrm{[b],[a]}}\\;|\\;\\mathbf{I}_{\\mathrm{[b][b]}}]$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "None\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Orcutt, G.H., Watts, H.W., & Edwards, J.B.(1968). \"Data aggregation and information loss\". The American\n",
-       "Economic Review, 58 , 773(787)](http://www.jstor.org/stable/1815532).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUp, title_level=3)"
    ]
@@ -450,81 +390,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.fit\n",
-       "\n",
-       ">      BottomUp.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                    idx_bottom:numpy.ndarray,\n",
-       ">                    y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                    intervals_method:Optional[str]=None,\n",
-       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                    tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*Bottom Up Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.fit\n",
-       "\n",
-       ">      BottomUp.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                    idx_bottom:numpy.ndarray,\n",
-       ">                    y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                    intervals_method:Optional[str]=None,\n",
-       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                    tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*Bottom Up Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUp.fit, name=\"BottomUp.fit\", title_level=3)"
    ]
@@ -533,59 +399,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.predict\n",
-       "\n",
-       ">      BottomUp.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                        level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.predict\n",
-       "\n",
-       ">      BottomUp.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                        level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUp.predict, name=\"BottomUp.predict\", title_level=3)"
    ]
@@ -594,87 +408,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.fit_predict\n",
-       "\n",
-       ">      BottomUp.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                            idx_bottom:numpy.ndarray,\n",
-       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                            level:Optional[list[int]]=None,\n",
-       ">                            intervals_method:Optional[str]=None,\n",
-       ">                            num_samples:Optional[int]=None,\n",
-       ">                            seed:Optional[int]=None,\n",
-       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*BottomUp Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.fit_predict\n",
-       "\n",
-       ">      BottomUp.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                            idx_bottom:numpy.ndarray,\n",
-       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                            level:Optional[list[int]]=None,\n",
-       ">                            intervals_method:Optional[str]=None,\n",
-       ">                            num_samples:Optional[int]=None,\n",
-       ">                            seed:Optional[int]=None,\n",
-       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*BottomUp Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUp.fit_predict, name=\"BottomUp.fit_predict\", title_level=3)"
    ]
@@ -683,59 +417,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.sample\n",
-       "\n",
-       ">      BottomUp.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUp.sample\n",
-       "\n",
-       ">      BottomUp.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUp.sample, name=\"BottomUp.sample\", title_level=3)"
    ]
@@ -775,53 +457,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L290){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse\n",
-       "\n",
-       ">      BottomUpSparse ()\n",
-       "\n",
-       "*BottomUpSparse Reconciliation Class.\n",
-       "\n",
-       "This is the implementation of a Bottom Up reconciliation using the sparse\n",
-       "matrix approach. It works much more efficient on datasets with many time series.\n",
-       "[makoren: At least I hope so, I only checked up until ~20k time series, and\n",
-       "there's no real improvement, it would be great to check for smth like 1M time\n",
-       "series, where the dense S matrix really stops fitting in memory]\n",
-       "\n",
-       "See the parent class for more details.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L290){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse\n",
-       "\n",
-       ">      BottomUpSparse ()\n",
-       "\n",
-       "*BottomUpSparse Reconciliation Class.\n",
-       "\n",
-       "This is the implementation of a Bottom Up reconciliation using the sparse\n",
-       "matrix approach. It works much more efficient on datasets with many time series.\n",
-       "[makoren: At least I hope so, I only checked up until ~20k time series, and\n",
-       "there's no real improvement, it would be great to check for smth like 1M time\n",
-       "series, where the dense S matrix really stops fitting in memory]\n",
-       "\n",
-       "See the parent class for more details.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUpSparse, title_level=3)"
    ]
@@ -830,83 +466,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.fit\n",
-       "\n",
-       ">      BottomUpSparse.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                          idx_bottom:numpy.ndarray,\n",
-       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                          intervals_method:Optional[str]=None,\n",
-       ">                          num_samples:Optional[int]=None,\n",
-       ">                          seed:Optional[int]=None,\n",
-       ">                          tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*Bottom Up Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L189){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.fit\n",
-       "\n",
-       ">      BottomUpSparse.fit (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                          idx_bottom:numpy.ndarray,\n",
-       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                          intervals_method:Optional[str]=None,\n",
-       ">                          num_samples:Optional[int]=None,\n",
-       ">                          seed:Optional[int]=None,\n",
-       ">                          tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*Bottom Up Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `horizon`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `horizon`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>        \n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUpSparse.fit, name=\"BottomUpSparse.fit\", title_level=3)"
    ]
@@ -915,59 +475,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.predict\n",
-       "\n",
-       ">      BottomUpSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                              level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.predict\n",
-       "\n",
-       ">      BottomUpSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                              level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUpSparse.predict, name=\"BottomUpSparse.predict\", title_level=3)"
    ]
@@ -976,87 +484,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.fit_predict\n",
-       "\n",
-       ">      BottomUpSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  idx_bottom:numpy.ndarray,\n",
-       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                  level:Optional[list[int]]=None,\n",
-       ">                                  intervals_method:Optional[str]=None,\n",
-       ">                                  num_samples:Optional[int]=None,\n",
-       ">                                  seed:Optional[int]=None,\n",
-       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*BottomUp Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L237){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.fit_predict\n",
-       "\n",
-       ">      BottomUpSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  idx_bottom:numpy.ndarray,\n",
-       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                  level:Optional[list[int]]=None,\n",
-       ">                                  intervals_method:Optional[str]=None,\n",
-       ">                                  num_samples:Optional[int]=None,\n",
-       ">                                  seed:Optional[int]=None,\n",
-       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*BottomUp Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: In-sample values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: In-sample forecast values of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>    \n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`**sampler_kwargs`: Coherent sampler instantiation arguments.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Bottom Up approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUpSparse.fit_predict, name=\"BottomUpSparse.fit_predict\", title_level=3)"
    ]
@@ -1065,59 +493,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.sample\n",
-       "\n",
-       ">      BottomUpSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### BottomUpSparse.sample\n",
-       "\n",
-       ">      BottomUpSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(BottomUpSparse.sample, name=\"BottomUpSparse.sample\", title_level=3)"
    ]
@@ -1573,67 +949,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L363){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown\n",
-       "\n",
-       ">      TopDown (method:str)\n",
-       "\n",
-       "*Top Down Reconciliation Class.\n",
-       "\n",
-       "The Top Down hierarchical reconciliation method, distributes the total aggregate predictions and decomposes\n",
-       "it down the hierarchy using proportions $\\mathbf{p}_{\\mathrm{[b]}}$ that can be actual historical values\n",
-       "or estimated.\n",
-       "\n",
-       "$$\\mathbf{P}=[\\mathbf{p}_{\\mathrm{[b]}}\\;|\\;\\mathbf{0}_{\\mathrm{[b][a,b\\;-1]}}]$$\n",
-       "**Parameters:**<br>\n",
-       "`method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [CW. Gross (1990). \"Disaggregation methods to expedite product line forecasting\". Journal of Forecasting, 9 , 233–254.\n",
-       "doi:10.1002/for.3980090304](https://onlinelibrary.wiley.com/doi/abs/10.1002/for.3980090304).<br>\n",
-       "- [G. Fliedner (1999). \"An investigation of aggregate variable time series forecast strategies with specific subaggregate\n",
-       "time series statistical correlation\". Computers and Operations Research, 26 , 1133–1149.\n",
-       "doi:10.1016/S0305-0548(99)00017-9](https://doi.org/10.1016/S0305-0548(99)00017-9).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L363){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown\n",
-       "\n",
-       ">      TopDown (method:str)\n",
-       "\n",
-       "*Top Down Reconciliation Class.\n",
-       "\n",
-       "The Top Down hierarchical reconciliation method, distributes the total aggregate predictions and decomposes\n",
-       "it down the hierarchy using proportions $\\mathbf{p}_{\\mathrm{[b]}}$ that can be actual historical values\n",
-       "or estimated.\n",
-       "\n",
-       "$$\\mathbf{P}=[\\mathbf{p}_{\\mathrm{[b]}}\\;|\\;\\mathbf{0}_{\\mathrm{[b][a,b\\;-1]}}]$$\n",
-       "**Parameters:**<br>\n",
-       "`method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [CW. Gross (1990). \"Disaggregation methods to expedite product line forecasting\". Journal of Forecasting, 9 , 233–254.\n",
-       "doi:10.1002/for.3980090304](https://onlinelibrary.wiley.com/doi/abs/10.1002/for.3980090304).<br>\n",
-       "- [G. Fliedner (1999). \"An investigation of aggregate variable time series forecast strategies with specific subaggregate\n",
-       "time series statistical correlation\". Computers and Operations Research, 26 , 1133–1149.\n",
-       "doi:10.1016/S0305-0548(99)00017-9](https://doi.org/10.1016/S0305-0548(99)00017-9).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDown, title_level=3)"
    ]
@@ -1642,79 +958,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.fit\n",
-       "\n",
-       ">      TopDown.fit (S, y_hat, y_insample:numpy.ndarray,\n",
-       ">                   y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                   sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                   intervals_method:Optional[str]=None,\n",
-       ">                   num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                   tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                   idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*TopDown Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.fit\n",
-       "\n",
-       ">      TopDown.fit (S, y_hat, y_insample:numpy.ndarray,\n",
-       ">                   y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                   sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                   intervals_method:Optional[str]=None,\n",
-       ">                   num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                   tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                   idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*TopDown Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDown.fit, name=\"TopDown.fit\", title_level=3)"
    ]
@@ -1723,59 +967,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.predict\n",
-       "\n",
-       ">      TopDown.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                       level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.predict\n",
-       "\n",
-       ">      TopDown.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                       level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDown.predict, name=\"TopDown.predict\", title_level=3)"
    ]
@@ -1784,87 +976,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L496){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.fit_predict\n",
-       "\n",
-       ">      TopDown.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                           tags:dict[str,numpy.ndarray],\n",
-       ">                           idx_bottom:numpy.ndarray=None,\n",
-       ">                           y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                           y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                           sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                           level:Optional[list[int]]=None,\n",
-       ">                           intervals_method:Optional[str]=None,\n",
-       ">                           num_samples:Optional[int]=None,\n",
-       ">                           seed:Optional[int]=None)\n",
-       "\n",
-       "*Top Down Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L496){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.fit_predict\n",
-       "\n",
-       ">      TopDown.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                           tags:dict[str,numpy.ndarray],\n",
-       ">                           idx_bottom:numpy.ndarray=None,\n",
-       ">                           y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                           y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                           sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                           level:Optional[list[int]]=None,\n",
-       ">                           intervals_method:Optional[str]=None,\n",
-       ">                           num_samples:Optional[int]=None,\n",
-       ">                           seed:Optional[int]=None)\n",
-       "\n",
-       "*Top Down Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDown.fit_predict, name=\"TopDown.fit_predict\", title_level=3)"
    ]
@@ -1873,59 +985,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.sample\n",
-       "\n",
-       ">      TopDown.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDown.sample\n",
-       "\n",
-       ">      TopDown.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDown.sample, name=\"TopDown.sample\", title_level=3)"
    ]
@@ -2088,47 +1148,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L574){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse\n",
-       "\n",
-       ">      TopDownSparse (method:str)\n",
-       "\n",
-       "*TopDownSparse Reconciliation Class.\n",
-       "\n",
-       "This is an implementation of top-down reconciliation using the sparse matrix\n",
-       "approach. It works much more efficiently on data sets with many time series.\n",
-       "\n",
-       "See the parent class for more details.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L574){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse\n",
-       "\n",
-       ">      TopDownSparse (method:str)\n",
-       "\n",
-       "*TopDownSparse Reconciliation Class.\n",
-       "\n",
-       "This is an implementation of top-down reconciliation using the sparse matrix\n",
-       "approach. It works much more efficiently on data sets with many time series.\n",
-       "\n",
-       "See the parent class for more details.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDownSparse, title_level=3)"
    ]
@@ -2137,81 +1157,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.fit\n",
-       "\n",
-       ">      TopDownSparse.fit (S, y_hat, y_insample:numpy.ndarray,\n",
-       ">                         y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                         sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                         intervals_method:Optional[str]=None,\n",
-       ">                         num_samples:Optional[int]=None,\n",
-       ">                         seed:Optional[int]=None,\n",
-       ">                         tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                         idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*TopDown Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L446){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.fit\n",
-       "\n",
-       ">      TopDownSparse.fit (S, y_hat, y_insample:numpy.ndarray,\n",
-       ">                         y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                         sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                         intervals_method:Optional[str]=None,\n",
-       ">                         num_samples:Optional[int]=None,\n",
-       ">                         seed:Optional[int]=None,\n",
-       ">                         tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                         idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*TopDown Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`interval_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDownSparse.fit, name=\"TopDownSparse.fit\", title_level=3)"
    ]
@@ -2220,59 +1166,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.predict\n",
-       "\n",
-       ">      TopDownSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                             level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.predict\n",
-       "\n",
-       ">      TopDownSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                             level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDownSparse.predict, name=\"TopDownSparse.predict\", title_level=3)"
    ]
@@ -2281,89 +1175,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L640){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.fit_predict\n",
-       "\n",
-       ">      TopDownSparse.fit_predict (S:scipy.sparse._csr.csr_matrix,\n",
-       ">                                 y_hat:numpy.ndarray,\n",
-       ">                                 tags:dict[str,numpy.ndarray],\n",
-       ">                                 idx_bottom:numpy.ndarray=None,\n",
-       ">                                 y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                 y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                 sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                 level:Optional[list[int]]=None,\n",
-       ">                                 intervals_method:Optional[str]=None,\n",
-       ">                                 num_samples:Optional[int]=None,\n",
-       ">                                 seed:Optional[int]=None)\n",
-       "\n",
-       "*Top Down Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L640){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.fit_predict\n",
-       "\n",
-       ">      TopDownSparse.fit_predict (S:scipy.sparse._csr.csr_matrix,\n",
-       ">                                 y_hat:numpy.ndarray,\n",
-       ">                                 tags:dict[str,numpy.ndarray],\n",
-       ">                                 idx_bottom:numpy.ndarray=None,\n",
-       ">                                 y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                 y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                 sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                 level:Optional[list[int]]=None,\n",
-       ">                                 intervals_method:Optional[str]=None,\n",
-       ">                                 num_samples:Optional[int]=None,\n",
-       ">                                 seed:Optional[int]=None)\n",
-       "\n",
-       "*Top Down Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Optional for `forecast_proportions` method.<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Top Down approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDownSparse.fit_predict, name=\"TopDownSparse.fit_predict\", title_level=3)"
    ]
@@ -2372,59 +1184,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.sample\n",
-       "\n",
-       ">      TopDownSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### TopDownSparse.sample\n",
-       "\n",
-       ">      TopDownSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TopDownSparse.sample, name=\"TopDownSparse.sample\", title_level=3)"
    ]
@@ -2463,24 +1223,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[10., 10.],\n",
-       "       [ 3.,  3.],\n",
-       "       [ 7.,  7.],\n",
-       "       [ 1.,  1.],\n",
-       "       [ 2.,  2.],\n",
-       "       [ 3.,  3.],\n",
-       "       [ 4.,  4.]])"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cls_top_down(\n",
     "                S=S, y_hat=S @ y_hat_bottom, y_insample=S @ y_bottom, tags=tags\n",
@@ -2745,63 +1488,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L721){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut\n",
-       "\n",
-       ">      MiddleOut (middle_level:str, top_down_method:str)\n",
-       "\n",
-       "*Middle Out Reconciliation Class.\n",
-       "\n",
-       "This method is only available for **strictly hierarchical structures**. It anchors the base predictions\n",
-       "in a middle level. The levels above the base predictions use the Bottom-Up approach, while the levels\n",
-       "below use a Top-Down.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`middle_level`: Middle level.<br>\n",
-       "`top_down_method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Hyndman, R.J., & Athanasopoulos, G. (2021). \"Forecasting: principles and practice, 3rd edition:\n",
-       "Chapter 11: Forecasting hierarchical and grouped series.\". OTexts: Melbourne, Australia. OTexts.com/fpp3\n",
-       "Accessed on July 2022.](https://otexts.com/fpp3/hierarchical.html)*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L721){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut\n",
-       "\n",
-       ">      MiddleOut (middle_level:str, top_down_method:str)\n",
-       "\n",
-       "*Middle Out Reconciliation Class.\n",
-       "\n",
-       "This method is only available for **strictly hierarchical structures**. It anchors the base predictions\n",
-       "in a middle level. The levels above the base predictions use the Bottom-Up approach, while the levels\n",
-       "below use a Top-Down.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`middle_level`: Middle level.<br>\n",
-       "`top_down_method`: One of `forecast_proportions`, `average_proportions` and `proportion_averages`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Hyndman, R.J., & Athanasopoulos, G. (2021). \"Forecasting: principles and practice, 3rd edition:\n",
-       "Chapter 11: Forecasting hierarchical and grouped series.\". OTexts: Melbourne, Australia. OTexts.com/fpp3\n",
-       "Accessed on July 2022.](https://otexts.com/fpp3/hierarchical.html)*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOut, title_level=3)"
    ]
@@ -2810,33 +1497,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.fit\n",
-       "\n",
-       ">      MiddleOut.fit (**kwargs)"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.fit\n",
-       "\n",
-       ">      MiddleOut.fit (**kwargs)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOut.fit, name=\"MiddleOut.fit\", title_level=3)"
    ]
@@ -2845,57 +1506,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.predict\n",
-       "\n",
-       ">      MiddleOut.predict (**kwargs)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.predict\n",
-       "\n",
-       ">      MiddleOut.predict (**kwargs)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOut.predict, name=\"MiddleOut.predict\", title_level=3)"
    ]
@@ -2904,67 +1515,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L764){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.fit_predict\n",
-       "\n",
-       ">      MiddleOut.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                             tags:dict[str,numpy.ndarray],\n",
-       ">                             y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                             level:Optional[list[int]]=None,\n",
-       ">                             intervals_method:Optional[str]=None)\n",
-       "\n",
-       "*Middle Out Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
-       "`level`: Not supported. <br>\n",
-       "`intervals_method`: Not supported.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L764){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.fit_predict\n",
-       "\n",
-       ">      MiddleOut.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                             tags:dict[str,numpy.ndarray],\n",
-       ">                             y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                             level:Optional[list[int]]=None,\n",
-       ">                             intervals_method:Optional[str]=None)\n",
-       "\n",
-       "*Middle Out Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
-       "`level`: Not supported. <br>\n",
-       "`intervals_method`: Not supported.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOut.fit_predict, title_level=3)"
    ]
@@ -2973,59 +1524,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.sample\n",
-       "\n",
-       ">      MiddleOut.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOut.sample\n",
-       "\n",
-       ">      MiddleOut.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOut.sample, name=\"MiddleOut.sample\", title_level=3)"
    ]
@@ -3143,47 +1642,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L858){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse\n",
-       "\n",
-       ">      MiddleOutSparse (middle_level:str, top_down_method:str)\n",
-       "\n",
-       "*MiddleOutSparse Reconciliation Class.\n",
-       "\n",
-       "This is an implementation of middle-out reconciliation using the sparse matrix\n",
-       "approach. It works much more efficiently on data sets with many time series.\n",
-       "\n",
-       "See the parent class for more details.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L858){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse\n",
-       "\n",
-       ">      MiddleOutSparse (middle_level:str, top_down_method:str)\n",
-       "\n",
-       "*MiddleOutSparse Reconciliation Class.\n",
-       "\n",
-       "This is an implementation of middle-out reconciliation using the sparse matrix\n",
-       "approach. It works much more efficiently on data sets with many time series.\n",
-       "\n",
-       "See the parent class for more details.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOutSparse, title_level=3)"
    ]
@@ -3192,33 +1651,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.fit\n",
-       "\n",
-       ">      MiddleOutSparse.fit (**kwargs)"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L758){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.fit\n",
-       "\n",
-       ">      MiddleOutSparse.fit (**kwargs)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOutSparse.fit, name=\"MiddleOutSparse.fit\", title_level=3)"
    ]
@@ -3227,57 +1660,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.predict\n",
-       "\n",
-       ">      MiddleOutSparse.predict (**kwargs)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L761){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.predict\n",
-       "\n",
-       ">      MiddleOutSparse.predict (**kwargs)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOutSparse.predict, name=\"MiddleOutSparse.predict\", title_level=3)"
    ]
@@ -3286,67 +1669,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L873){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.fit_predict\n",
-       "\n",
-       ">      MiddleOutSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                   tags:dict[str,numpy.ndarray],\n",
-       ">                                   y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                   level:Optional[list[int]]=None,\n",
-       ">                                   intervals_method:Optional[str]=None)\n",
-       "\n",
-       "*Middle Out Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
-       "`level`: Not supported. <br>\n",
-       "`intervals_method`: Not supported.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L873){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.fit_predict\n",
-       "\n",
-       ">      MiddleOutSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                   tags:dict[str,numpy.ndarray],\n",
-       ">                                   y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                   level:Optional[list[int]]=None,\n",
-       ">                                   intervals_method:Optional[str]=None)\n",
-       "\n",
-       "*Middle Out Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used for `forecast_proportions`<br>\n",
-       "`level`: Not supported. <br>\n",
-       "`intervals_method`: Not supported.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the Middle Out approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOutSparse.fit_predict, title_level=3)"
    ]
@@ -3355,59 +1678,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.sample\n",
-       "\n",
-       ">      MiddleOutSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MiddleOutSparse.sample\n",
-       "\n",
-       ">      MiddleOutSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MiddleOutSparse.sample, name=\"MiddleOutSparse.sample\", title_level=3)"
    ]
@@ -3845,87 +2116,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L960){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace\n",
-       "\n",
-       ">      MinTrace (method:str, nonnegative:bool=False,\n",
-       ">                mint_shr_ridge:Optional[float]=2e-08, num_threads:int=1)\n",
-       "\n",
-       "*MinTrace Reconciliation Class.\n",
-       "\n",
-       "This reconciliation algorithm proposed by Wickramasuriya et al. depends on a generalized least squares estimator\n",
-       "and an estimator of the covariance matrix of the coherency errors $\\mathbf{W}_{h}$. The Min Trace algorithm\n",
-       "minimizes the squared errors for the coherent forecasts under an unbiasedness assumption; the solution has a\n",
-       "closed form.<br>\n",
-       "\n",
-       "$$\n",
-       "\\mathbf{P}_{\\text{MinT}}=\\left(\\mathbf{S}^{\\intercal}\\mathbf{W}_{h}\\mathbf{S}\\right)^{-1}\n",
-       "\\mathbf{S}^{\\intercal}\\mathbf{W}^{-1}_{h}\n",
-       "$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `ols`, `wls_struct`, `wls_var`, `mint_shrink`, `mint_cov`.<br>\n",
-       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
-       "`mint_shr_ridge`: float=2e-8, ridge numeric protection to MinTrace-shr covariance estimator.<br>\n",
-       "`num_threads`: int=1, number of threads to use for solving the optimization problems (when nonnegative=True).\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Wickramasuriya, S. L., Athanasopoulos, G., & Hyndman, R. J. (2019). \"Optimal forecast reconciliation for\n",
-       "hierarchical and grouped time series through trace minimization\". Journal of the American Statistical Association,\n",
-       "114 , 804–819. doi:10.1080/01621459.2018.1448825.](https://robjhyndman.com/publications/mint/).\n",
-       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
-       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
-       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L960){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace\n",
-       "\n",
-       ">      MinTrace (method:str, nonnegative:bool=False,\n",
-       ">                mint_shr_ridge:Optional[float]=2e-08, num_threads:int=1)\n",
-       "\n",
-       "*MinTrace Reconciliation Class.\n",
-       "\n",
-       "This reconciliation algorithm proposed by Wickramasuriya et al. depends on a generalized least squares estimator\n",
-       "and an estimator of the covariance matrix of the coherency errors $\\mathbf{W}_{h}$. The Min Trace algorithm\n",
-       "minimizes the squared errors for the coherent forecasts under an unbiasedness assumption; the solution has a\n",
-       "closed form.<br>\n",
-       "\n",
-       "$$\n",
-       "\\mathbf{P}_{\\text{MinT}}=\\left(\\mathbf{S}^{\\intercal}\\mathbf{W}_{h}\\mathbf{S}\\right)^{-1}\n",
-       "\\mathbf{S}^{\\intercal}\\mathbf{W}^{-1}_{h}\n",
-       "$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `ols`, `wls_struct`, `wls_var`, `mint_shrink`, `mint_cov`.<br>\n",
-       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
-       "`mint_shr_ridge`: float=2e-8, ridge numeric protection to MinTrace-shr covariance estimator.<br>\n",
-       "`num_threads`: int=1, number of threads to use for solving the optimization problems (when nonnegative=True).\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Wickramasuriya, S. L., Athanasopoulos, G., & Hyndman, R. J. (2019). \"Optimal forecast reconciliation for\n",
-       "hierarchical and grouped time series through trace minimization\". Journal of the American Statistical Association,\n",
-       "114 , 804–819. doi:10.1080/01621459.2018.1448825.](https://robjhyndman.com/publications/mint/).\n",
-       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
-       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
-       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTrace, title_level=3)"
    ]
@@ -3934,79 +2125,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.fit\n",
-       "\n",
-       ">      MinTrace.fit (S, y_hat, y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                    intervals_method:Optional[str]=None,\n",
-       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                    tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                    idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTrace Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.fit\n",
-       "\n",
-       ">      MinTrace.fit (S, y_hat, y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                    sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                    intervals_method:Optional[str]=None,\n",
-       ">                    num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                    tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                    idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTrace Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTrace.fit, name=\"MinTrace.fit\", title_level=3)"
    ]
@@ -4015,59 +2134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.predict\n",
-       "\n",
-       ">      MinTrace.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                        level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.predict\n",
-       "\n",
-       ">      MinTrace.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                        level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTrace.predict, name=\"MinTrace.predict\", title_level=3)"
    ]
@@ -4076,87 +2143,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.fit_predict\n",
-       "\n",
-       ">      MinTrace.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                            idx_bottom:numpy.ndarray=None,\n",
-       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                            level:Optional[list[int]]=None,\n",
-       ">                            intervals_method:Optional[str]=None,\n",
-       ">                            num_samples:Optional[int]=None,\n",
-       ">                            seed:Optional[int]=None,\n",
-       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.fit_predict\n",
-       "\n",
-       ">      MinTrace.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                            idx_bottom:numpy.ndarray=None,\n",
-       ">                            y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                            sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                            level:Optional[list[int]]=None,\n",
-       ">                            intervals_method:Optional[str]=None,\n",
-       ">                            num_samples:Optional[int]=None,\n",
-       ">                            seed:Optional[int]=None,\n",
-       ">                            tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTrace.fit_predict, name=\"MinTrace.fit_predict\", title_level=3)"
    ]
@@ -4165,59 +2152,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.sample\n",
-       "\n",
-       ">      MinTrace.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTrace.sample\n",
-       "\n",
-       ">      MinTrace.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTrace.sample, name=\"MinTrace.sample\", title_level=3)"
    ]
@@ -4558,65 +2493,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1280){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse\n",
-       "\n",
-       ">      MinTraceSparse (method:str, nonnegative:bool=False, num_threads:int=1,\n",
-       ">                      qp:bool=True)\n",
-       "\n",
-       "*MinTraceSparse Reconciliation Class.\n",
-       "\n",
-       "This is the implementation of OLS and WLS estimators using sparse matrices. It is not guaranteed\n",
-       "to give identical results to the non-sparse version, but works much more efficiently on data sets\n",
-       "with many time series.<br>\n",
-       "\n",
-       "See the parent class for more details.<br>\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `ols`, `wls_struct`, or `wls_var`.<br>\n",
-       "`nonnegative`: bool, return non-negative reconciled forecasts.<br>\n",
-       "`num_threads`: int, number of threads to execute non-negative quadratic programming calls.<br>\n",
-       "`qp`: bool, implement non-negativity constraint with a quadratic programming approach. Setting \n",
-       "this to True generally gives better results, but at the expense of higher cost to compute. <br>*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1280){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse\n",
-       "\n",
-       ">      MinTraceSparse (method:str, nonnegative:bool=False, num_threads:int=1,\n",
-       ">                      qp:bool=True)\n",
-       "\n",
-       "*MinTraceSparse Reconciliation Class.\n",
-       "\n",
-       "This is the implementation of OLS and WLS estimators using sparse matrices. It is not guaranteed\n",
-       "to give identical results to the non-sparse version, but works much more efficiently on data sets\n",
-       "with many time series.<br>\n",
-       "\n",
-       "See the parent class for more details.<br>\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `ols`, `wls_struct`, or `wls_var`.<br>\n",
-       "`nonnegative`: bool, return non-negative reconciled forecasts.<br>\n",
-       "`num_threads`: int, number of threads to execute non-negative quadratic programming calls.<br>\n",
-       "`qp`: bool, implement non-negativity constraint with a quadratic programming approach. Setting \n",
-       "this to True generally gives better results, but at the expense of higher cost to compute. <br>*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTraceSparse, title_level=3)"
    ]
@@ -4625,83 +2502,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1401){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.fit\n",
-       "\n",
-       ">      MinTraceSparse.fit (S:scipy.sparse._csr.csr_matrix, y_hat:numpy.ndarray,\n",
-       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                          intervals_method:Optional[str]=None,\n",
-       ">                          num_samples:Optional[int]=None,\n",
-       ">                          seed:Optional[int]=None,\n",
-       ">                          tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                          idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTraceSparse Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1401){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.fit\n",
-       "\n",
-       ">      MinTraceSparse.fit (S:scipy.sparse._csr.csr_matrix, y_hat:numpy.ndarray,\n",
-       ">                          y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                          sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                          intervals_method:Optional[str]=None,\n",
-       ">                          num_samples:Optional[int]=None,\n",
-       ">                          seed:Optional[int]=None,\n",
-       ">                          tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                          idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTraceSparse Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTraceSparse.fit, name=\"MinTraceSparse.fit\", title_level=3)"
    ]
@@ -4710,59 +2511,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.predict\n",
-       "\n",
-       ">      MinTraceSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                              level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.predict\n",
-       "\n",
-       ">      MinTraceSparse.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                              level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTraceSparse.predict, name=\"MinTraceSparse.predict\", title_level=3)"
    ]
@@ -4771,87 +2520,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.fit_predict\n",
-       "\n",
-       ">      MinTraceSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  idx_bottom:numpy.ndarray=None,\n",
-       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                  level:Optional[list[int]]=None,\n",
-       ">                                  intervals_method:Optional[str]=None,\n",
-       ">                                  num_samples:Optional[int]=None,\n",
-       ">                                  seed:Optional[int]=None,\n",
-       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.fit_predict\n",
-       "\n",
-       ">      MinTraceSparse.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  idx_bottom:numpy.ndarray=None,\n",
-       ">                                  y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                                  sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                  level:Optional[list[int]]=None,\n",
-       ">                                  intervals_method:Optional[str]=None,\n",
-       ">                                  num_samples:Optional[int]=None,\n",
-       ">                                  seed:Optional[int]=None,\n",
-       ">                                  tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTraceSparse.fit_predict, name=\"MinTraceSparse.fit_predict\", title_level=3)"
    ]
@@ -4860,59 +2529,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.sample\n",
-       "\n",
-       ">      MinTraceSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### MinTraceSparse.sample\n",
-       "\n",
-       ">      MinTraceSparse.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(MinTraceSparse.sample, name=\"MinTraceSparse.sample\", title_level=3)"
    ]
@@ -4921,16 +2538,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\ospra\\AppData\\Local\\Temp\\ipykernel_40652\\2921588021.py:48: UserWarning: `num_threads` is only used when `nonnegative=True`\n",
-      "  warnings.warn(\"`num_threads` is only used when `nonnegative=True`\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "for method in [\"ols\", \"wls_struct\", \"wls_var\", \"mint_shrink\"]:\n",
@@ -5102,79 +2710,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1607){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination\n",
-       "\n",
-       ">      OptimalCombination (method:str, nonnegative:bool=False,\n",
-       ">                          num_threads:int=1)\n",
-       "\n",
-       "*Optimal Combination Reconciliation Class.\n",
-       "\n",
-       "This reconciliation algorithm was proposed by Hyndman et al. 2011, the method uses generalized least squares\n",
-       "estimator using the coherency errors covariance matrix. Consider the covariance of the base forecast\n",
-       "$\\textrm{Var}(\\epsilon_{h}) = \\Sigma_{h}$, the $\\mathbf{P}$ matrix of this method is defined by:\n",
-       "$$ \\mathbf{P} = \\left(\\mathbf{S}^{\\intercal}\\Sigma_{h}^{\\dagger}\\mathbf{S}\\right)^{-1}\\mathbf{S}^{\\intercal}\\Sigma^{\\dagger}_{h}$$\n",
-       "where $\\Sigma_{h}^{\\dagger}$ denotes the variance pseudo-inverse. The method was later proven equivalent to\n",
-       "`MinTrace` variants.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, allowed optimal combination methods: 'ols', 'wls_struct'.<br>\n",
-       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Rob J. Hyndman, Roman A. Ahmed, George Athanasopoulos, Han Lin Shang (2010). \"Optimal Combination Forecasts for\n",
-       "Hierarchical Time Series\".](https://robjhyndman.com/papers/Hierarchical6.pdf).<br>\n",
-       "- [Shanika L. Wickramasuriya, George Athanasopoulos and Rob J. Hyndman (2010). \"Optimal Combination Forecasts for\n",
-       "Hierarchical Time Series\".](https://robjhyndman.com/papers/MinT.pdf).\n",
-       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
-       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
-       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1607){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination\n",
-       "\n",
-       ">      OptimalCombination (method:str, nonnegative:bool=False,\n",
-       ">                          num_threads:int=1)\n",
-       "\n",
-       "*Optimal Combination Reconciliation Class.\n",
-       "\n",
-       "This reconciliation algorithm was proposed by Hyndman et al. 2011, the method uses generalized least squares\n",
-       "estimator using the coherency errors covariance matrix. Consider the covariance of the base forecast\n",
-       "$\\textrm{Var}(\\epsilon_{h}) = \\Sigma_{h}$, the $\\mathbf{P}$ matrix of this method is defined by:\n",
-       "$$ \\mathbf{P} = \\left(\\mathbf{S}^{\\intercal}\\Sigma_{h}^{\\dagger}\\mathbf{S}\\right)^{-1}\\mathbf{S}^{\\intercal}\\Sigma^{\\dagger}_{h}$$\n",
-       "where $\\Sigma_{h}^{\\dagger}$ denotes the variance pseudo-inverse. The method was later proven equivalent to\n",
-       "`MinTrace` variants.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, allowed optimal combination methods: 'ols', 'wls_struct'.<br>\n",
-       "`nonnegative`: bool, reconciled forecasts should be nonnegative?<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Rob J. Hyndman, Roman A. Ahmed, George Athanasopoulos, Han Lin Shang (2010). \"Optimal Combination Forecasts for\n",
-       "Hierarchical Time Series\".](https://robjhyndman.com/papers/Hierarchical6.pdf).<br>\n",
-       "- [Shanika L. Wickramasuriya, George Athanasopoulos and Rob J. Hyndman (2010). \"Optimal Combination Forecasts for\n",
-       "Hierarchical Time Series\".](https://robjhyndman.com/papers/MinT.pdf).\n",
-       "- [Wickramasuriya, S.L., Turlach, B.A. & Hyndman, R.J. (2020). \"Optimal non-negative\n",
-       "forecast reconciliation\". Stat Comput 30, 1167–1182,\n",
-       "https://doi.org/10.1007/s11222-020-09930-0](https://robjhyndman.com/publications/nnmint/).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(OptimalCombination, title_level=3)"
    ]
@@ -5183,83 +2719,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.fit\n",
-       "\n",
-       ">      OptimalCombination.fit (S, y_hat,\n",
-       ">                              y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                              y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                              sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                              intervals_method:Optional[str]=None,\n",
-       ">                              num_samples:Optional[int]=None,\n",
-       ">                              seed:Optional[int]=None,\n",
-       ">                              tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                              idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTrace Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1111){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.fit\n",
-       "\n",
-       ">      OptimalCombination.fit (S, y_hat,\n",
-       ">                              y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                              y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                              sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                              intervals_method:Optional[str]=None,\n",
-       ">                              num_samples:Optional[int]=None,\n",
-       ">                              seed:Optional[int]=None,\n",
-       ">                              tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">                              idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*MinTrace Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\".<br>\n",
-       "`y_hat_insample`: Insample forecast values of size (`base`, `insample_size`). Only used with \"wls_var\", \"mint_cov\", \"mint_shrink\"<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(OptimalCombination.fit, name=\"OptimalCombination.fit\", title_level=3)"
    ]
@@ -5268,59 +2728,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.predict\n",
-       "\n",
-       ">      OptimalCombination.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.predict\n",
-       "\n",
-       ">      OptimalCombination.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                  level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(OptimalCombination.predict, name=\"OptimalCombination.predict\", title_level=3)"
    ]
@@ -5329,87 +2737,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.fit_predict\n",
-       "\n",
-       ">      OptimalCombination.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                      idx_bottom:numpy.ndarray=None,\n",
-       ">                                      y_insample:Optional[numpy.ndarray]=None, \n",
-       ">                                      y_hat_insample:Optional[numpy.ndarray]=No\n",
-       ">                                      ne, sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                      level:Optional[list[int]]=None,\n",
-       ">                                      intervals_method:Optional[str]=None,\n",
-       ">                                      num_samples:Optional[int]=None,\n",
-       ">                                      seed:Optional[int]=None, tags:Optional[di\n",
-       ">                                      ct[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1217){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.fit_predict\n",
-       "\n",
-       ">      OptimalCombination.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                                      idx_bottom:numpy.ndarray=None,\n",
-       ">                                      y_insample:Optional[numpy.ndarray]=None, \n",
-       ">                                      y_hat_insample:Optional[numpy.ndarray]=No\n",
-       ">                                      ne, sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                                      level:Optional[list[int]]=None,\n",
-       ">                                      intervals_method:Optional[str]=None,\n",
-       ">                                      num_samples:Optional[int]=None,\n",
-       ">                                      seed:Optional[int]=None, tags:Optional[di\n",
-       ">                                      ct[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*MinTrace Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Insample values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`y_hat_insample`: Insample fitted values of size (`base`, `insample_size`). Only used by `wls_var`, `mint_cov`, `mint_shrink`<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the MinTrace approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(\n",
     "    OptimalCombination.fit_predict, name=\"OptimalCombination.fit_predict\", title_level=3\n",
@@ -5420,59 +2748,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.sample\n",
-       "\n",
-       ">      OptimalCombination.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### OptimalCombination.sample\n",
-       "\n",
-       ">      OptimalCombination.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(OptimalCombination.sample, name=\"OptimalCombination.sample\", title_level=3)"
    ]
@@ -5720,77 +2996,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1642){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM\n",
-       "\n",
-       ">      ERM (method:str, lambda_reg:float=0.01)\n",
-       "\n",
-       "*Empirical Risk Minimization Reconciliation Class.\n",
-       "\n",
-       "The Empirical Risk Minimization reconciliation strategy relaxes the unbiasedness assumptions from\n",
-       "previous reconciliation methods like MinT and optimizes square errors between the reconciled predictions\n",
-       "and the validation data to obtain an optimal reconciliation matrix P.\n",
-       "\n",
-       "The exact solution for $\\mathbf{P}$ (`method='closed'`) follows the expression:\n",
-       "$$\\mathbf{P}^{*} = \\left(\\mathbf{S}^{\\intercal}\\mathbf{S}\\right)^{-1}\\mathbf{Y}^{\\intercal}\\hat{\\mathbf{Y}}\\left(\\hat{\\mathbf{Y}}\\hat{\\mathbf{Y}}\\right)^{-1}$$\n",
-       "\n",
-       "The alternative Lasso regularized $\\mathbf{P}$ solution (`method='reg_bu'`) is useful when the observations\n",
-       "of validation data is limited or the exact solution has low numerical stability.\n",
-       "$$\\mathbf{P}^{*} = \\text{argmin}_{\\mathbf{P}} ||\\mathbf{Y}-\\mathbf{S} \\mathbf{P} \\hat{Y} ||^{2}_{2} + \\lambda ||\\mathbf{P}-\\mathbf{P}_{\\text{BU}}||_{1}$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `closed`, `reg` and `reg_bu`.<br>\n",
-       "`lambda_reg`: float, l1 regularizer for `reg` and `reg_bu`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Ben Taieb, S., & Koo, B. (2019). Regularized regression for hierarchical forecasting without\n",
-       "unbiasedness conditions. In Proceedings of the 25th ACM SIGKDD International Conference on Knowledge\n",
-       "Discovery & Data Mining KDD '19 (p. 1337-1347). New York, NY, USA: Association for Computing Machinery.](https://doi.org/10.1145/3292500.3330976).<br>*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1642){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM\n",
-       "\n",
-       ">      ERM (method:str, lambda_reg:float=0.01)\n",
-       "\n",
-       "*Empirical Risk Minimization Reconciliation Class.\n",
-       "\n",
-       "The Empirical Risk Minimization reconciliation strategy relaxes the unbiasedness assumptions from\n",
-       "previous reconciliation methods like MinT and optimizes square errors between the reconciled predictions\n",
-       "and the validation data to obtain an optimal reconciliation matrix P.\n",
-       "\n",
-       "The exact solution for $\\mathbf{P}$ (`method='closed'`) follows the expression:\n",
-       "$$\\mathbf{P}^{*} = \\left(\\mathbf{S}^{\\intercal}\\mathbf{S}\\right)^{-1}\\mathbf{Y}^{\\intercal}\\hat{\\mathbf{Y}}\\left(\\hat{\\mathbf{Y}}\\hat{\\mathbf{Y}}\\right)^{-1}$$\n",
-       "\n",
-       "The alternative Lasso regularized $\\mathbf{P}$ solution (`method='reg_bu'`) is useful when the observations\n",
-       "of validation data is limited or the exact solution has low numerical stability.\n",
-       "$$\\mathbf{P}^{*} = \\text{argmin}_{\\mathbf{P}} ||\\mathbf{Y}-\\mathbf{S} \\mathbf{P} \\hat{Y} ||^{2}_{2} + \\lambda ||\\mathbf{P}-\\mathbf{P}_{\\text{BU}}||_{1}$$\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`method`: str, one of `closed`, `reg` and `reg_bu`.<br>\n",
-       "`lambda_reg`: float, l1 regularizer for `reg` and `reg_bu`.<br>\n",
-       "\n",
-       "**References:**<br>\n",
-       "- [Ben Taieb, S., & Koo, B. (2019). Regularized regression for hierarchical forecasting without\n",
-       "unbiasedness conditions. In Proceedings of the 25th ACM SIGKDD International Conference on Knowledge\n",
-       "Discovery & Data Mining KDD '19 (p. 1337-1347). New York, NY, USA: Association for Computing Machinery.](https://doi.org/10.1145/3292500.3330976).<br>*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(ERM, title_level=3)"
    ]
@@ -5799,77 +3005,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1736){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.fit\n",
-       "\n",
-       ">      ERM.fit (S, y_hat, y_insample, y_hat_insample,\n",
-       ">               sigmah:Optional[numpy.ndarray]=None,\n",
-       ">               intervals_method:Optional[str]=None,\n",
-       ">               num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">               tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">               idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*ERM Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1736){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.fit\n",
-       "\n",
-       ">      ERM.fit (S, y_hat, y_insample, y_hat_insample,\n",
-       ">               sigmah:Optional[numpy.ndarray]=None,\n",
-       ">               intervals_method:Optional[str]=None,\n",
-       ">               num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">               tags:Optional[dict[str,numpy.ndarray]]=None,\n",
-       ">               idx_bottom:Optional[numpy.ndarray]=None)\n",
-       "\n",
-       "*ERM Fit Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`self`: object, fitted reconciler.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(ERM.fit, name=\"ERM.fit\", title_level=3)"
    ]
@@ -5878,59 +3014,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.predict\n",
-       "\n",
-       ">      ERM.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                   level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L106){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.predict\n",
-       "\n",
-       ">      ERM.predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                   level:Optional[list[int]]=None)\n",
-       "\n",
-       "*Predict using reconciler.\n",
-       "\n",
-       "Predict using fitted mean and probabilistic reconcilers.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated predictions.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(ERM.predict, name=\"ERM.predict\", title_level=3)"
    ]
@@ -5939,85 +3023,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1789){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.fit_predict\n",
-       "\n",
-       ">      ERM.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                       idx_bottom:numpy.ndarray=None,\n",
-       ">                       y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                       y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                       sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                       level:Optional[list[int]]=None,\n",
-       ">                       intervals_method:Optional[str]=None,\n",
-       ">                       num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                       tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*ERM Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the ERM approach.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L1789){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.fit_predict\n",
-       "\n",
-       ">      ERM.fit_predict (S:numpy.ndarray, y_hat:numpy.ndarray,\n",
-       ">                       idx_bottom:numpy.ndarray=None,\n",
-       ">                       y_insample:Optional[numpy.ndarray]=None,\n",
-       ">                       y_hat_insample:Optional[numpy.ndarray]=None,\n",
-       ">                       sigmah:Optional[numpy.ndarray]=None,\n",
-       ">                       level:Optional[list[int]]=None,\n",
-       ">                       intervals_method:Optional[str]=None,\n",
-       ">                       num_samples:Optional[int]=None, seed:Optional[int]=None,\n",
-       ">                       tags:Optional[dict[str,numpy.ndarray]]=None)\n",
-       "\n",
-       "*ERM Reconciliation Method.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`S`: Summing matrix of size (`base`, `bottom`).<br>\n",
-       "`y_hat`: Forecast values of size (`base`, `horizon`).<br>\n",
-       "`idx_bottom`: Indices corresponding to the bottom level of `S`, size (`bottom`).<br>\n",
-       "`y_insample`: Train values of size (`base`, `insample_size`).<br>\n",
-       "`y_hat_insample`: Insample train predictions of size (`base`, `insample_size`).<br>\n",
-       "`sigmah`: Estimated standard deviation of the conditional marginal distribution.<br>\n",
-       "`level`: float list 0-100, confidence levels for prediction intervals.<br>\n",
-       "`intervals_method`: Sampler for prediction intervals, one of `normality`, `bootstrap`, `permbu`.<br>\n",
-       "`num_samples`: Number of samples for probabilistic coherent distribution.<br>\n",
-       "`seed`: Seed for reproducibility.<br>\n",
-       "`tags`: Each key is a level and each value its `S` indices.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`y_tilde`: Reconciliated y_hat using the ERM approach.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(ERM.fit_predict, name=\"ERM.fit_predict\", title_level=3)"
    ]
@@ -6026,59 +3032,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.sample\n",
-       "\n",
-       ">      ERM.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/Nixtla/hierarchicalforecast/blob/main/hierarchicalforecast/methods.py#L128){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "### ERM.sample\n",
-       "\n",
-       ">      ERM.sample (num_samples:int)\n",
-       "\n",
-       "*Sample probabilistic coherent distribution.\n",
-       "\n",
-       "Generates n samples from a probabilistic coherent distribution.\n",
-       "The method uses fitted mean and probabilistic reconcilers, defined by\n",
-       "the `intervals_method` selected during the reconciler's\n",
-       "instantiation. Currently available: `normality`, `bootstrap`, `permbu`.\n",
-       "\n",
-       "**Parameters:**<br>\n",
-       "`num_samples`: int, number of samples generated from coherent distribution.<br>\n",
-       "\n",
-       "**Returns:**<br>\n",
-       "`samples`: Coherent samples of size (`num_series`, `horizon`, `num_samples`).*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(ERM.sample, name=\"ERM.sample\", title_level=3)"
    ]


### PR DESCRIPTION
`TopDown(method="forecast_proportions")` should fail when provided a non-strict hierarchy. We capture this for `TopDownSparse`, but not for `TopDown`. This PR adds a strictness check to `TopDown` when used with `forecast_proportions`.

The error can be reproduced by running the Prison population example from the docs, which contains a non-strict hierarchy that **doesn't** fail when using `TopDown(method="forecast_proportions")` as reconciler, whereas it should fail. 

After this PR, a user is given the error message that `TopDown(method="forecast_proportions")` requires a strict hierarchy.