### PR TITLE
use `backend=` instead of deprecated `native_namespace=` in `nw.from_dict`

### DIFF
--- a/hierarchicalforecast/evaluation.py
+++ b/hierarchicalforecast/evaluation.py
@@ -486,7 +486,7 @@ class HierarchicalEvaluation:
                 },
                 **dict(zip(model_names, evaluation_np.T)),
             },
-            native_namespace=native_namespace,
+            backend=native_namespace,
         )
 
         evaluation = evaluation_nw.to_native()

--- a/nbs/src/evaluation.ipynb
+++ b/nbs/src/evaluation.ipynb
@@ -536,7 +536,7 @@
     "                **{\"level\": evaluation_index_np[:, 0], \"metric\": evaluation_index_np[:, 1]},\n",
     "                **dict(zip(model_names, evaluation_np.T))\n",
     "            }, \n",
-    "            native_namespace=native_namespace)\n",
+    "            backend=native_namespace)\n",
     "\n",
     "        evaluation = evaluation_nw.to_native()\n",
     "\n",


### PR DESCRIPTION
`native_namespace` in `nw.from_dict` is deprecated since Narwhals 1.27, which is already your minimum version

https://github.com/Nixtla/hierarchicalforecast/blob/434c411c475e8b5ce852943e018e77e16c198f05/settings.ini#L18

so is safe to do even for the oldest versions

For future reference, I'd also suggest using `narwhals.stable.v1` to guard against API changes https://narwhals-dev.github.io/narwhals/backcompat/