### PR TITLE
perf: vectorize bootstrap sampling and sparse child-node lookup

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -58,4 +58,4 @@ jobs:
             uv pip install datasetsforecast "statsforecast>=1.0.0"
             scipy "polars[numpy]<=1.32.0" pytest pytest-benchmark pytest-cov
           CIBW_TEST_COMMAND: >
-            pytest {project}/tests --no-cov --import-mode=importlib
+            pytest {project}/tests --no-cov --import-mode=importlib -m "not benchmark"

--- a/hierarchicalforecast/methods.py
+++ b/hierarchicalforecast/methods.py
@@ -340,24 +340,54 @@ class BottomUpSparse(BottomUp):
         return P, W
 
 
+def _rows_to_bool_csr(S: np.ndarray | sparse.spmatrix, rows: np.ndarray) -> sparse.csr_matrix:
+    """Extract `rows` from `S` as a boolean sparse matrix.
+
+    Only the requested rows are ever materialized, so this never densifies a
+    (potentially huge) sparse `S`, unlike a blanket `S.toarray()`.
+    """
+    if sparse.issparse(S):
+        sub = S.tocsr()[rows].astype(bool)
+        sub.eliminate_zeros()
+        return sub
+    return sparse.csr_matrix(np.asarray(S)[rows] != 0)
+
+
 def _get_child_nodes(
     S: np.ndarray | sparse.csr_matrix, tags: dict[str, np.ndarray]
 ):
-    if isinstance(S, sparse.spmatrix):
-        S = S.toarray()
+    """Build, for each level, a mapping from parent index to its child indices.
+
+    Note:
+        The child-parent overlap test assumes `S` is nonnegative (true for
+        standard 0/1 hierarchical summing matrices): it checks for any shared
+        nonzero bottom-level column between a child row and a parent row,
+        which only matches "sum of overlapping values > 0" when there is no
+        sign cancellation between entries.
+    """
     level_names = list(tags.keys())
     nodes = OrderedDict()
     for i_level, level in enumerate(level_names[:-1]):
         parent = tags[level]
-        child = np.zeros_like(S)
         idx_child = tags[level_names[i_level + 1]]
-        child[idx_child] = S[idx_child]
+
+        parent_bool = _rows_to_bool_csr(S, parent)
+        child_bool = _rows_to_bool_csr(S, idx_child)
+
+        # overlap[c, p] is nonzero iff child row `c` and parent row `p` share at
+        # least one nonzero bottom-level column (i.e. child `c` descends from
+        # parent `p`). This replaces the dense `child * parent_node.astype(bool)`
+        # check (and the O(n_bottom^2)-worst-case `idx in idx_node` membership
+        # scan) with a single sparse matmul plus O(1) column lookups.
+        overlap = (child_bool @ parent_bool.T).tocsc()
+        overlap.sort_indices()
+
         nodes_level = {}
-        for idx_parent_node in parent:
-            parent_node = S[idx_parent_node]
-            idx_node = child * parent_node.astype(bool)
-            (idx_node,) = np.where(idx_node.sum(axis=1) > 0)
-            nodes_level[idx_parent_node] = [idx for idx in idx_child if idx in idx_node]
+        for p_pos, idx_parent_node in enumerate(parent):
+            start, end = overlap.indptr[p_pos], overlap.indptr[p_pos + 1]
+            nodes_level[idx_parent_node] = [
+                idx_child[c_pos] for c_pos in overlap.indices[start:end]
+            ]
         nodes[level] = nodes_level
     return nodes
 

--- a/hierarchicalforecast/probabilistic_methods.py
+++ b/hierarchicalforecast/probabilistic_methods.py
@@ -570,6 +570,12 @@ class Bootstrap:
 
         Returns:
             samples: Coherent samples of size (`base`, `horizon`, `num_samples`).
+
+        Note:
+            When `S` and/or `P` are sparse, `SP = S @ P` stays sparse and the
+            reconciliation matmul is a sparse-dense product; `SP` is never
+            densified, so memory stays proportional to `S`/`P`'s nonzeros
+            instead of `base x base`.
         """
         residuals = self.y_insample - self.y_hat_insample
         h = self.y_hat.shape[1]
@@ -581,11 +587,34 @@ class Bootstrap:
         samples_idx = rng.choice(sample_idx, size=num_samples)
         samples = [self.y_hat + residuals[:, idx : (idx + h)] for idx in samples_idx]
         SP = self.S @ self.P
-        samples = np.apply_along_axis(lambda path: SP @ path, axis=1, arr=samples)
-        samples_np = np.stack(samples)
 
-        # [samples, N, H] -> [N, H, samples]
-        samples_np = samples_np.transpose((1, 2, 0))
+        # Stack into a single (num_samples, n_series, h) array and reconcile all
+        # samples with one batched matmul instead of looping via
+        # `np.apply_along_axis` (which calls the lambda once per (sample, horizon)
+        # pair under the hood). Flattening (samples, horizon) into one axis lets
+        # this go through a single BLAS `dgemm` call (or scipy sparse matmul,
+        # when `SP` is sparse, which is left sparse here so large hierarchies
+        # don't force an OOM-inducing dense `SP` allocation) rather than
+        # `np.einsum`, which is dramatically slower here since it can't
+        # express this contraction as a plain matrix product without
+        # `optimize=True`.
+        samples_arr = np.stack(samples)
+        # samples_arr.shape[-1] is `h` by construction (each entry is
+        # `y_hat + residuals[:, idx:(idx+h)]`), so we reuse the outer `h`
+        # instead of rebinding it to a shadowing local of the same value.
+        n_samples, n_series, _ = samples_arr.shape
+        flat = np.moveaxis(samples_arr, 1, 0).reshape(n_series, n_samples * h)
+        # `samples` and `samples_arr` are independent copies of the sampled
+        # paths at this point (the moveaxis+reshape above produced its own
+        # copy in `flat`), so drop them before the matmul to keep peak memory
+        # to roughly 2x the output buffer instead of holding every
+        # intermediate alive at once.
+        del samples, samples_arr
+        reconciled = SP @ flat
+        samples_np = reconciled.reshape(SP.shape[0], n_samples, h)
+
+        # [N, samples, H] -> [N, H, samples]
+        samples_np = samples_np.transpose((0, 2, 1))
         return samples_np
 
     def get_prediction_levels(self, res, level):

--- a/hierarchicalforecast/probabilistic_methods.py
+++ b/hierarchicalforecast/probabilistic_methods.py
@@ -713,9 +713,8 @@ class PERMBU:
         """
         temp = array.argsort(axis=1)
         ranks = np.empty_like(temp)
-        a_range = np.arange(temp.shape[1])
-        for i_row in range(temp.shape[0]):
-            ranks[i_row, temp[i_row, :]] = a_range
+        a_range = np.broadcast_to(np.arange(temp.shape[1]), temp.shape)
+        np.put_along_axis(ranks, temp, a_range, axis=1)
         return ranks
 
     def _permutate_samples(self, samples, permutations):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,6 @@ addopts = [
     "--cov-report=html",
     "--cov-fail-under=70", #TODO: Update tests to increase coverage to 80
 ]
+markers = [
+    "benchmark: pytest-benchmark timing tests (excluded from the wheel test matrix in CI; run explicitly with `-m benchmark`)",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,60 @@ def assert_raises_with_message(func, expected_msg, *args, **kwargs):
         func(*args, **kwargs)
     assert expected_msg in str(exc_info.value)
 
+
+def _random_partition(rng, n_items, n_parts):
+    """Split `n_items` (shuffled) indices into `n_parts` non-empty groups."""
+    order = rng.permutation(n_items)
+    if n_parts > 1:
+        cuts = sorted(rng.choice(np.arange(1, n_items), size=n_parts - 1, replace=False))
+    else:
+        cuts = []
+    groups = []
+    prev = 0
+    for cut in [*cuts, n_items]:
+        groups.append(order[prev:cut])
+        prev = cut
+    return groups
+
+
+def _make_random_strict_hierarchy(rng, level_sizes, shuffle_tags=True):
+    """Build a random strictly hierarchical `S` matrix and `tags` for testing.
+
+    `level_sizes` goes from top to bottom, e.g. `[1, 5, 9, 40]`. Each node's
+    children are a random non-empty partition of the level below, so the
+    result is guaranteed strictly hierarchical. Row order within each level's
+    `tags` entry is shuffled by default (row indices are still valid, but not
+    in ascending order) to make sure ordering isn't accidentally assumed to
+    follow `np.where`'s ascending output.
+
+    Shared by `tests/test_methods.py` (correctness fuzzing) and
+    `tests/test_benchmarks.py` (synthetic benchmark hierarchies) so the two
+    suites don't drift apart on their own copies of the same generator.
+    """
+    n_bottom = level_sizes[-1]
+    memberships = [np.eye(n_bottom, dtype=np.float64)]
+    current_size = n_bottom
+    for size in reversed(level_sizes[:-1]):
+        groups = _random_partition(rng, current_size, size)
+        prev_membership = memberships[-1]
+        new_membership = np.zeros((size, n_bottom))
+        for i, grp in enumerate(groups):
+            new_membership[i] = prev_membership[grp].sum(axis=0)
+        memberships.append(new_membership)
+        current_size = size
+    memberships = list(reversed(memberships))
+    S = np.vstack(memberships)
+
+    tags = {}
+    row_offset = 0
+    for i, size in enumerate(level_sizes):
+        idx = np.arange(row_offset, row_offset + size)
+        if shuffle_tags:
+            idx = rng.permutation(idx)
+        tags[f"level{i}"] = idx
+        row_offset += size
+    return S, tags
+
 @pytest.fixture(scope="module")
 def tourism_df():
     df = pd.read_csv('https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/tourism.csv')

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,12 +1,19 @@
 import numpy as np
 import pytest
+from scipy import sparse
 
+from hierarchicalforecast.methods import _get_child_nodes
+from hierarchicalforecast.probabilistic_methods import Bootstrap
 from hierarchicalforecast.utils import (
     _lasso,
     _ma_cov,
     _shrunk_covariance_schaferstrimmer_no_nans,
     _shrunk_covariance_schaferstrimmer_with_nans,
 )
+
+from .conftest import _make_random_strict_hierarchy
+
+pytestmark = pytest.mark.benchmark
 
 
 @pytest.fixture(params=[50, 200, 500, 1000])
@@ -45,3 +52,60 @@ def lasso_data():
 def test_bench_lasso(benchmark, lasso_data):
     X, y = lasso_data
     benchmark(_lasso, X, y, 0.1, 1000, 1e-4)
+
+
+@pytest.fixture
+def bootstrap_bench_data():
+    """1000 bottom series, 3 levels (top / mid / bottom), matching the
+    synthetic hierarchy used to benchmark the `Bootstrap.get_samples`
+    vectorization."""
+    rng = np.random.default_rng(123)
+    S, _ = _make_random_strict_hierarchy(
+        rng, level_sizes=[1, 20, 1000], shuffle_tags=False
+    )
+    n_hiers, n_bottom = S.shape
+    h = 12
+    insample_size = 60
+
+    y_insample = 100.0 + 10.0 * rng.standard_normal((n_hiers, insample_size))
+    y_hat_insample = y_insample + rng.standard_normal((n_hiers, insample_size))
+    y_hat = 100.0 + 10.0 * rng.standard_normal((n_hiers, h))
+    P = np.eye(n_bottom, n_hiers, n_hiers - n_bottom, np.float64)
+    return S, P, y_hat, y_insample, y_hat_insample
+
+
+@pytest.mark.parametrize("as_sparse", [False, True], ids=["dense", "sparse"])
+def test_bench_bootstrap_get_samples(benchmark, bootstrap_bench_data, as_sparse):
+    S, P, y_hat, y_insample, y_hat_insample = bootstrap_bench_data
+    if as_sparse:
+        S = sparse.csr_matrix(S)
+        P = sparse.csr_matrix(P)
+    sampler = Bootstrap(
+        S=S,
+        P=P,
+        y_hat=y_hat,
+        y_insample=y_insample,
+        y_hat_insample=y_hat_insample,
+        num_samples=1000,
+        seed=0,
+    )
+    benchmark(sampler.get_samples, num_samples=1000)
+
+
+@pytest.fixture
+def child_nodes_bench_data():
+    """Same synthetic 1000-bottom-series/3-level hierarchy, for benchmarking
+    `_get_child_nodes` (feeds TopDown/MiddleOut `forecast_proportions`)."""
+    rng = np.random.default_rng(456)
+    S, tags = _make_random_strict_hierarchy(
+        rng, level_sizes=[1, 20, 1000], shuffle_tags=False
+    )
+    return S, tags
+
+
+@pytest.mark.parametrize("as_sparse", [False, True], ids=["dense", "sparse"])
+def test_bench_get_child_nodes(benchmark, child_nodes_bench_data, as_sparse):
+    S, tags = child_nodes_bench_data
+    if as_sparse:
+        S = sparse.csr_matrix(S)
+    benchmark(_get_child_nodes, S=S, tags=tags)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,3 +1,4 @@
+import zlib
 from dataclasses import dataclass
 
 import numpy as np
@@ -14,10 +15,13 @@ from hierarchicalforecast.methods import (
     OptimalCombination,
     TopDown,
     TopDownSparse,
+    _get_child_nodes,
     _is_strictly_hierarchical,
     is_strictly_hierarchical,
 )
 from hierarchicalforecast.utils import _construct_adjacency_matrix
+
+from .conftest import _make_random_strict_hierarchy
 
 
 @dataclass
@@ -1104,3 +1108,144 @@ def test_emint_nonnegative_raises_on_bootstrap_permbu(hierarchical_data, interva
             seed=42,
             tags=data.tags,
             )
+
+
+def _get_child_nodes_old(S, tags):
+    """Reference (pre-optimization) implementation of `_get_child_nodes`.
+
+    Densifies `S` unconditionally and, for every parent node, filters the
+    child-level indices with a Python `idx in idx_node` membership scan. Kept
+    here only to assert the vectorized/sparse-aware rewrite in
+    `hierarchicalforecast.methods._get_child_nodes` is exactly equivalent.
+    """
+    if sparse.issparse(S):
+        S = S.toarray()
+    level_names = list(tags.keys())
+    nodes = {}
+    for i_level, level in enumerate(level_names[:-1]):
+        parent = tags[level]
+        child = np.zeros_like(S)
+        idx_child = tags[level_names[i_level + 1]]
+        child[idx_child] = S[idx_child]
+        nodes_level = {}
+        for idx_parent_node in parent:
+            parent_node = S[idx_parent_node]
+            idx_node = child * parent_node.astype(bool)
+            (idx_node,) = np.where(idx_node.sum(axis=1) > 0)
+            nodes_level[idx_parent_node] = [idx for idx in idx_child if idx in idx_node]
+        nodes[level] = nodes_level
+    return nodes
+
+
+class TestGetChildNodes:
+    """Regression tests for the sparse-aware, vectorized `_get_child_nodes`.
+
+    The old implementation always densified `S` and filtered each parent's
+    children with a Python `idx in idx_node` scan (worst case
+    O(n_parents * n_bottom**2)). The rewrite uses a boolean sparse matmul
+    plus O(1) column lookups per parent but must return the exact same
+    `{level: {parent_idx: [child_idx, ...]}}` structure, in the exact same
+    order.
+    """
+
+    def test_matches_reference_dense_fixture(self, hierarchical_data):
+        data = hierarchical_data
+        new_nodes = _get_child_nodes(S=data.S, tags=data.tags)
+        old_nodes = _get_child_nodes_old(S=data.S, tags=data.tags)
+
+        assert list(new_nodes.keys()) == list(old_nodes.keys())
+        for level in old_nodes:
+            assert list(new_nodes[level].keys()) == list(old_nodes[level].keys())
+            for parent in old_nodes[level]:
+                assert list(new_nodes[level][parent]) == list(old_nodes[level][parent])
+
+    def test_matches_reference_sparse_input(self, hierarchical_data):
+        data = hierarchical_data
+        S_sparse = sparse.csr_matrix(data.S)
+        new_nodes = _get_child_nodes(S=S_sparse, tags=data.tags)
+        old_nodes = _get_child_nodes_old(S=data.S, tags=data.tags)
+
+        for level in old_nodes:
+            for parent in old_nodes[level]:
+                assert list(new_nodes[level][parent]) == list(old_nodes[level][parent])
+
+    @pytest.mark.parametrize(
+        "level_sizes",
+        [
+            [1, 2, 4],
+            [1, 5, 9, 40],
+            [1, 3, 7, 100],
+            [1, 40],
+        ],
+    )
+    @pytest.mark.parametrize("as_sparse", [False, True])
+    def test_matches_reference_random_hierarchies(self, level_sizes, as_sparse):
+        """Fuzz `_get_child_nodes` against the reference on random trees.
+
+        Covers multi-level hierarchies, uneven fan-out per parent, and
+        shuffled (non-ascending) `tags` ordering, for both dense and sparse
+        `S`.
+        """
+        # `hash()` on a tuple is salted per-process (PYTHONHASHSEED), so it
+        # would give an unreproducible seed across runs/machines. crc32 over a
+        # fixed string representation is deterministic instead.
+        seed = zlib.crc32(
+            repr(("get_child_nodes", tuple(level_sizes), as_sparse)).encode()
+        )
+        rng = np.random.default_rng(seed)
+        S, tags = _make_random_strict_hierarchy(rng, level_sizes)
+        S_input = sparse.csr_matrix(S) if as_sparse else S
+
+        new_nodes = _get_child_nodes(S=S_input, tags=tags)
+        old_nodes = _get_child_nodes_old(S=S, tags=tags)
+
+        assert list(new_nodes.keys()) == list(old_nodes.keys())
+        for level in old_nodes:
+            assert list(new_nodes[level].keys()) == list(old_nodes[level].keys())
+            for parent in old_nodes[level]:
+                new_children = list(new_nodes[level][parent])
+                old_children = list(old_nodes[level][parent])
+                assert new_children == old_children, (
+                    f"level={level!r} parent={parent}: {new_children} != {old_children}"
+                )
+
+    @pytest.mark.parametrize("as_sparse", [False, True])
+    def test_singleton_child_parent(self, as_sparse):
+        """Hand-written hierarchy with a parent that has exactly one child.
+
+        Random hierarchies from `_make_random_strict_hierarchy` aren't
+        guaranteed to ever produce a singleton-child parent, so this pins
+        that edge case explicitly: level0 has two parents, one ("A") with
+        two children and one ("B") with a single child.
+        """
+        # 3 bottom series b1, b2, b3.
+        # level0: A (row 0) = A1 + A2, B (row 1) = B1 -- B has only one child.
+        # level1: A1 (row 2), A2 (row 3), B1 (row 4).
+        S = np.array(
+            [
+                [1.0, 1.0, 0.0],  # A = A1 + A2
+                [0.0, 0.0, 1.0],  # B = B1
+                [1.0, 0.0, 0.0],  # A1
+                [0.0, 1.0, 0.0],  # A2
+                [0.0, 0.0, 1.0],  # B1
+            ]
+        )
+        tags = {
+            "level0": np.array([0, 1]),
+            "level1": np.array([2, 3, 4]),
+        }
+        S_input = sparse.csr_matrix(S) if as_sparse else S
+
+        new_nodes = _get_child_nodes(S=S_input, tags=tags)
+        old_nodes = _get_child_nodes_old(S=S, tags=tags)
+
+        assert new_nodes["level0"] == old_nodes["level0"]
+        assert list(new_nodes["level0"][0]) == [2, 3]
+        assert list(new_nodes["level0"][1]) == [4]
+
+    def test_feeds_top_down_forecast_proportions_correctly(self, hierarchical_data):
+        """End-to-end: TopDown's `forecast_proportions` output is unaffected."""
+        data = hierarchical_data
+        cls_top_down = TopDown(method="forecast_proportions")
+        result = cls_top_down(S=data.S, y_hat=data.S @ data.y_hat_bottom, tags=data.tags)["mean"]
+        np.testing.assert_allclose(result, data.S @ data.y_hat_bottom)

--- a/tests/test_probabilistic_methods.py
+++ b/tests/test_probabilistic_methods.py
@@ -1093,3 +1093,196 @@ class TestConformal:
             conformal.get_samples(num_samples=-5)
         assert "positive integer" in str(exc_info.value)
 
+
+class TestBootstrapVectorization:
+    """Regression tests for the vectorized `Bootstrap.get_samples` reconciliation step.
+
+    `get_samples` used to reconcile each bootstrap sample path with
+    `np.apply_along_axis`, which invokes a Python lambda once per
+    (sample, horizon) pair. It was replaced with a batched reshape + matmul
+    (a single BLAS `dgemm`/sparse matmul call over all samples at once,
+    deliberately not `np.einsum`, which can't express this contraction as a
+    plain matrix product without `optimize=True`); these tests pin the old,
+    known-correct behavior so a future change can't silently alter the
+    result.
+    """
+
+    @staticmethod
+    def _old_reconcile(y_hat, residuals, S, P, num_samples, seed):
+        """Reimplementation of the pre-vectorization reconciliation step."""
+        h = y_hat.shape[1]
+        residuals = residuals[:, np.isnan(residuals).sum(axis=0) == 0]
+        sample_idx = np.arange(residuals.shape[1] - h)
+        rng = np.random.default_rng(seed)
+        samples_idx = rng.choice(sample_idx, size=num_samples)
+        samples = [y_hat + residuals[:, idx : (idx + h)] for idx in samples_idx]
+        SP = S @ P
+        samples = np.apply_along_axis(lambda path: SP @ path, axis=1, arr=samples)
+        samples_np = np.stack(samples)
+        return samples_np.transpose((1, 2, 0))
+
+    def test_matches_apply_along_axis_reference(self, test_data):
+        """New reshape+matmul reconciliation matches the old apply_along_axis result."""
+        cls_bottom_up = BottomUp()
+        P, W = cls_bottom_up._get_PW_matrices(S=test_data["S"])
+
+        sampler = Bootstrap(
+            S=test_data["S"],
+            P=P,
+            W=W,
+            y_hat=test_data["y_hat_base"],
+            y_insample=test_data["y_base"],
+            y_hat_insample=test_data["y_hat_base_insample"],
+            num_samples=200,
+            seed=7,
+        )
+        new_samples = sampler.get_samples(num_samples=200)
+
+        residuals = test_data["y_base"] - test_data["y_hat_base_insample"]
+        old_samples = self._old_reconcile(
+            y_hat=test_data["y_hat_base"],
+            residuals=residuals,
+            S=test_data["S"],
+            P=P.toarray() if sp.issparse(P) else P,
+            num_samples=200,
+            seed=7,
+        )
+
+        np.testing.assert_allclose(new_samples, old_samples, rtol=1e-10, atol=1e-10)
+
+    def test_matches_apply_along_axis_reference_with_sparse_S(self, test_data):
+        """The vectorized path also matches the reference when S/P are sparse."""
+        cls_bottom_up = BottomUp()
+        S_sparse = sp.csr_matrix(test_data["S"])
+        P, W = cls_bottom_up._get_PW_matrices(S=S_sparse)
+
+        sampler = Bootstrap(
+            S=S_sparse,
+            P=P,
+            W=W,
+            y_hat=test_data["y_hat_base"],
+            y_insample=test_data["y_base"],
+            y_hat_insample=test_data["y_hat_base_insample"],
+            num_samples=150,
+            seed=3,
+        )
+        new_samples = sampler.get_samples(num_samples=150)
+
+        residuals = test_data["y_base"] - test_data["y_hat_base_insample"]
+        old_samples = self._old_reconcile(
+            y_hat=test_data["y_hat_base"],
+            residuals=residuals,
+            S=test_data["S"],
+            P=P.toarray() if sp.issparse(P) else P,
+            num_samples=150,
+            seed=3,
+        )
+
+        np.testing.assert_allclose(new_samples, old_samples, rtol=1e-10, atol=1e-10)
+
+    def test_matches_apply_along_axis_reference_single_sample_single_horizon(
+        self, test_data
+    ):
+        """Degenerate `num_samples=1`, `h=1` case.
+
+        The reshape/matmul path collapses to a single (n_series, 1) vector,
+        which is the shape most likely to trip up axis-juggling bugs in the
+        batched reshape.
+        """
+        cls_bottom_up = BottomUp()
+        P, W = cls_bottom_up._get_PW_matrices(S=test_data["S"])
+
+        y_hat_h1 = test_data["y_hat_base"][:, :1]
+
+        sampler = Bootstrap(
+            S=test_data["S"],
+            P=P,
+            W=W,
+            y_hat=y_hat_h1,
+            y_insample=test_data["y_base"],
+            y_hat_insample=test_data["y_hat_base_insample"],
+            num_samples=1,
+            seed=11,
+        )
+        new_samples = sampler.get_samples(num_samples=1)
+
+        residuals = test_data["y_base"] - test_data["y_hat_base_insample"]
+        old_samples = self._old_reconcile(
+            y_hat=y_hat_h1,
+            residuals=residuals,
+            S=test_data["S"],
+            P=P.toarray() if sp.issparse(P) else P,
+            num_samples=1,
+            seed=11,
+        )
+
+        assert new_samples.shape == (test_data["S"].shape[0], 1, 1)
+        np.testing.assert_allclose(new_samples, old_samples, rtol=1e-10, atol=1e-10)
+
+
+class TestPermbuObtainRanksVectorization:
+    """Regression tests for the vectorized `PERMBU._obtain_ranks`.
+
+    The old implementation filled the ranks matrix with a Python `for` loop
+    over rows; the new one uses a single `np.put_along_axis` call. Ranks are
+    integer positions, so the two implementations must match *exactly*.
+    """
+
+    @staticmethod
+    def _old_obtain_ranks(array):
+        temp = array.argsort(axis=1)
+        ranks = np.empty_like(temp)
+        a_range = np.arange(temp.shape[1])
+        for i_row in range(temp.shape[0]):
+            ranks[i_row, temp[i_row, :]] = a_range
+        return ranks
+
+    @pytest.mark.parametrize("shape", [(1, 1), (1, 5), (5, 1), (7, 4), (50, 30)])
+    def test_matches_loop_reference(self, test_data, shape):
+        cls_bottom_up = BottomUp()
+        P, _ = cls_bottom_up._get_PW_matrices(S=test_data["S"])
+        permbu_sampler = PERMBU(
+            S=test_data["S"],
+            P=P,
+            tags=test_data["tags"],
+            y_hat=test_data["y_hat_base"],
+            y_insample=test_data["y_base"],
+            y_hat_insample=test_data["y_hat_base_insample"],
+            sigmah=test_data["sigmah"],
+        )
+
+        rng = np.random.default_rng(42)
+        array = rng.standard_normal(shape)
+
+        new_ranks = permbu_sampler._obtain_ranks(array)
+        old_ranks = self._old_obtain_ranks(array)
+
+        np.testing.assert_array_equal(new_ranks, old_ranks)
+
+    def test_matches_loop_reference_with_ties(self, test_data):
+        """Ties (equal values) exercise argsort's tie-breaking; ranks must still match."""
+        cls_bottom_up = BottomUp()
+        P, _ = cls_bottom_up._get_PW_matrices(S=test_data["S"])
+        permbu_sampler = PERMBU(
+            S=test_data["S"],
+            P=P,
+            tags=test_data["tags"],
+            y_hat=test_data["y_hat_base"],
+            y_insample=test_data["y_base"],
+            y_hat_insample=test_data["y_hat_base_insample"],
+            sigmah=test_data["sigmah"],
+        )
+
+        array = np.array(
+            [
+                [1.0, 2.0, 2.0, 1.0, 3.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+            ]
+        )
+
+        new_ranks = permbu_sampler._obtain_ranks(array)
+        old_ranks = self._old_obtain_ranks(array)
+
+        np.testing.assert_array_equal(new_ranks, old_ranks)
+


### PR DESCRIPTION

## What

Three pure-Python/numpy hotspots, no changes to the C++ extension in `src/`:

1. `Bootstrap.get_samples` (`hierarchicalforecast/probabilistic_methods.py`) reconciled every bootstrap sample path with `np.apply_along_axis`, which is a hidden Python loop calling a lambda once per `(sample, horizon)` pair. Replaced with a single batched matmul.
2. `PERMBU._obtain_ranks` (same file) filled a ranks matrix with an explicit Python `for` loop over rows. Replaced with a single `np.put_along_axis` call.
3. `_get_child_nodes` (`hierarchicalforecast/methods.py`), which backs `TopDown`/`MiddleOut` `forecast_proportions`, unconditionally densified `S` with `S.toarray()` and then filtered each parent's children with a Python `idx in idx_node` membership scan over a numpy array (worst case `O(n_parents * n_bottom**2)`). Replaced with a sparse boolean matmul plus O(1) column lookups, and `S` is never densified.

`PERMBU`'s per-level `random_permutation` loop (the other spot called out in scope) was investigated and deliberately left untouched — see "The RNG decision" below.

## Why

All three were flagged as pure-Python-loop-shaped hotspots with no numerical dependency on the C++ backend. `Bootstrap.get_samples` and `_get_child_nodes` scale badly (the former re-enters Python once per sample/horizon pair, the latter is quadratic in the bottom-level series count), which matters for larger hierarchies (thousands of bottom series, hundreds/thousands of bootstrap samples).

## How

### 1. `Bootstrap.get_samples`

Before:
```python
samples = [self.y_hat + residuals[:, idx:(idx+h)] for idx in samples_idx]
SP = self.S @ self.P
samples = np.apply_along_axis(lambda path: SP @ path, axis=1, arr=samples)
```

After, the sampled paths are stacked into `(num_samples, n_series, h)`, then reshaped so a single dense matmul reconciles every sample and horizon at once:

```python
samples_arr = np.stack(samples)
n_samples, n_series, _ = samples_arr.shape  # last dim is `h`; reuse the outer `h`, don't rebind
flat = np.moveaxis(samples_arr, 1, 0).reshape(n_series, n_samples * h)
del samples, samples_arr  # both are independent copies of the sampled paths by this point
reconciled = SP @ flat
samples_np = reconciled.reshape(SP.shape[0], n_samples, h)
```

Note: an `np.einsum('ij,sjh->sih', SP, samples_arr)` version was tried first and is numerically identical, but **`np.einsum` without `optimize=True` does not route this contraction through BLAS** — it fell back to a naive summation loop and was ~60x *slower* than the original `apply_along_axis` code on the benchmark hierarchy (12.8s vs the reshape+matmul's 0.2s in an isolated microbenchmark). The reshape+`@` form always uses a single `dgemm` call and doesn't depend on numpy's einsum path-optimizer, so it's the one shipped here.

**`SP` stays sparse when `S`/`P` are sparse** — an earlier version of this diff called `SP.toarray()` on the theory that `SP` (`base x base`) is "much smaller than `S`", which is wrong: `SP` is `base x base`, which is `>= S`'s `base x bottom`, so densifying it would OOM the `*Sparse` reconcilers on large hierarchies (e.g. ~8TB at 1M series). `SP @ flat` and `SP.shape[0]` both work directly against a sparse `SP`, so the `.toarray()` call was removed; a reviewer's sparse-vs-dense probe confirmed the two paths agree to 1e-12.

**Peak memory**: `samples` and `samples_arr` are dropped (`del`) right after the `flat` reshape/copy exists, since both are redundant copies of the same data by that point. Isolating just this one-line change (reshape+matmul with vs. without the `del`, same algorithm both sides, at `n_series=1021`, `h=12`, `num_samples=20000`, macOS `/usr/bin/time -l` peak RSS): **~6.1GB with the `del` vs. ~8.1GB without** (~1.3x lower peak) — real, reproduced numbers from this machine, not the original estimate. Comparing the full old (`apply_along_axis`) implementation against the new one at the same shape, wall time dropped from **~35-47s to ~3.0-3.3s (~11-14x)**; the peak-RSS delta between old and new algorithms was harder to isolate cleanly at the process level (both hover near ~6.1GB, since the ~2GB output array itself dominates the measurement and macOS's allocator doesn't always return freed pages to the OS immediately), but the `del`-only comparison above shows the memory saving is real.

Verified with `np.testing.assert_allclose` against a reimplementation of the old `apply_along_axis` logic (dense and sparse `S`/`P`); max abs diff was `~3e-10`, consistent with float summation-order differences.

### 2. `PERMBU._obtain_ranks`

```python
temp = array.argsort(axis=1)
ranks = np.empty_like(temp)
a_range = np.broadcast_to(np.arange(temp.shape[1]), temp.shape)
np.put_along_axis(ranks, temp, a_range, axis=1)
```

Verified with `np.testing.assert_array_equal` (exact integer equality, including a tie-breaking case) against the old loop. Honesty check on performance: at realistic sizes (hundreds to ~100k rows) this is **not a measurable win** — the old loop's per-row body was already a fully vectorized numpy assignment, so removing the Python `for` only saves loop overhead that was already dominated by the row-sized work inside it. Measured speedup was ~0.8x–1.5x (noise-level) across row counts from 100 to 100,000. Kept anyway because it's exactly equivalent, removes an explicit loop, and is what was asked for — but it is not being sold as a performance fix.

### 3. `_get_child_nodes`

Before, for every `(level, parent)` pair: `S.toarray()` once up front, then `child = np.zeros_like(S); child[idx_child] = S[idx_child]`, then per parent `idx_node = child * parent_node.astype(bool)` (dense elementwise multiply over the *entire* `S`) followed by `[idx for idx in idx_child if idx in idx_node]`, a Python-level linear scan.

After: for each level pair, extract only the `parent`/`idx_child` rows as boolean sparse matrices (never densifying all of `S`), then a single sparse matmul `child_bool @ parent_bool.T` gives, in one shot, which child rows overlap with which parent rows (a shared nonzero bottom-level column — the same condition the old dense code checked). Each parent's children are then read off via `O(1)` CSC column slicing (`indptr`/`indices`), with `sort_indices()` guaranteeing they come out in the same relative order as the original `idx_child` array (this was the subtle part — the old code implicitly preserved `idx_child`'s order via the list comprehension, and the new code has to replicate that explicitly rather than relying on `np.where`'s ascending order).

Verified against a reimplementation of the old dense/`toarray()` logic for: the existing 3-level fixture, sparse and dense `S` inputs, and randomly generated multi-level (up to 4 levels) hierarchies with **shuffled (non-ascending) tag ordering** — specifically to catch a rewrite that accidentally returns children sorted by row index instead of by `idx_child`'s given order.

### The RNG decision

`PERMBU.get_samples` also has this loop, mentioned in scope:

```python
random_permutation = np.array([
    rng.permutation(np.arange(num_samples)) for serie in range(len(parent_samples))
])
```

This is replaceable with `rng.permuted(...)`, but doing so **changes the RNG draw sequence** — same seed, different sample stream. Checked the test suite (`tests/test_probabilistic_methods.py`, `tests/test_core.py`) for anything pinning exact seeded PERMBU output: there is none (existing seed tests for PERMBU/Bootstrap only check reproducibility — same seed in, same output out — and shape, not literal values).

Even so, benchmarked both versions (Python-loop-of-`rng.permutation` vs one `rng.permuted` call) across realistic `(n_parents, num_samples)` combinations for this loop specifically (n_parents is the node count at one hierarchy level, typically tens, not thousands):

| n_parents | num_samples | old (loop) | new (`permuted`) | speedup |
|---:|---:|---:|---:|---:|
| 5 | 1000 | 2.5ms | 2.2ms | 1.15x |
| 20 | 1000 | 11.8ms | 8.0ms | 1.47x |
| 100 | 100 | 13.8ms | 5.0ms | 2.73x |
| 100 | 5000 | 333.8ms | 288.0ms | 1.16x |

The gain tops out around ~2.7x only at small `num_samples`, and is closer to 1.1–1.3x at realistic sizes, because the permutation algorithm itself (Fisher–Yates, `O(num_samples)`) dominates the cost either way — the Python loop overhead being removed was never the bottleneck here (unlike `_get_child_nodes`, where the removed loop was the asymptotic bottleneck). Per the "default to the conservative option for RNG-affecting lines unless the speedup is meaningful" rule: no test pins exact values, but the speedup isn't meaningful enough to justify a public, silent change to every downstream user's seeded PERMBU sample stream. **Left untouched.** Happy to revisit if maintainers consider a documented RNG-stream-breaking change acceptable for this magnitude of gain.

## Benchmarks

Synthetic hierarchy: 1000 bottom series, 3 levels (top=1, mid=20, bottom=1000), `num_samples=1000` where applicable. Measured by reimplementing the old logic inline and timing both against the same inputs (`min` of 3–10 repeats after warmup); see method in the PR — not committed as a script. Machine: Apple Silicon (arm64) laptop.

| Function | Old | New | Speedup |
|---|---:|---:|---:|
| `Bootstrap.get_samples` | ~2.88s | ~0.18s | **~16x** |
| `_get_child_nodes` (dense `S`) | ~133ms | ~7.6ms | **~17x** |
| `_get_child_nodes` (sparse `S`) | ~154ms | ~0.6ms | **~274x** |
| `PERMBU._obtain_ranks` | ~22ms | ~23ms | ~1x (no real change, see above) |

`_get_child_nodes` scaling with bottom-series count (dense vs dense, sparse vs sparse, same shape both sides):

| n_bottom | old (dense) | new (dense) | speedup | old (sparse) | new (sparse) | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 200 | 11.2ms | 0.98ms | 11.4x | 7.4ms | 0.36ms | 20.8x |
| 1000 | 133.2ms | 7.6ms | 17.5x | 153.7ms | 0.56ms | 273.6x |
| 5000 | 1413.2ms | 141.1ms | 10.0x | 1555.6ms | 1.0ms | 1562x |

The sparse-`S` speedup grows with hierarchy size because the old code paid the same `O(n_bottom^2)` cost regardless of input sparsity (it densified first), while the new code's cost tracks the actual number of nonzeros.

`pytest-benchmark` fixtures for `Bootstrap.get_samples` and `_get_child_nodes` were added to `tests/test_benchmarks.py` (same synthetic hierarchy), each parametrized over dense and sparse `S`/`P` so the sparse code paths get benchmark coverage too, not just the dense ones; they measure the current (post-fix) implementation only, since `pytest-benchmark` isn't set up here to diff against a prior git revision.

`tests/test_benchmarks.py` is excluded from the cibuildwheel CI test matrix (`.github/workflows/pytest.yml`): every `test_bench_*` function is now tagged `benchmark` (registered in `pyproject.toml`), and `CIBW_TEST_COMMAND` passes `-m "not benchmark"`. Without this, the ~20s of benchmark timing runs would execute in all 20 matrix jobs, including the QEMU-emulated `manylinux_aarch64` job, where they could balloon well past their normal duration. Benchmarks still run in a plain `pytest` invocation or explicitly via `-m benchmark`.

## Post-review fixes

This branch went through a round of code review; all findings were addressed:

- **Blocking**: removed the `SP.toarray()` densification in `Bootstrap.get_samples` (see the sparse-`SP` note above); added the `del samples, samples_arr` peak-memory fix (see above); excluded `tests/test_benchmarks.py` from the wheel test matrix (see above).
- **Minors**: replaced the per-process-salted `hash()` fuzz seed in `test_methods.py` with a deterministic `zlib.crc32` seed; reworded stale "einsum" docstrings/test names in `test_probabilistic_methods.py` to "batched reshape + matmul"; removed dead-code `nodes_level` dict-comprehension initializer in `_get_child_nodes` (immediately overwritten by the loop); documented the nonnegative-`S` assumption behind `_get_child_nodes`'s shared-nonzero-column overlap test and the sparse-`S`/`P` behavior of `Bootstrap.get_samples`, both as docstring notes; added a `num_samples=1`/`h=1` Bootstrap regression test and a hand-written singleton-child-parent `_get_child_nodes` fixture (random fuzzing isn't guaranteed to produce one); moved the duplicated `_make_random_strict_hierarchy` test helper (drifted between `test_methods.py` and `test_benchmarks.py`) into `conftest.py` for both to share; stopped rebinding `h` to a same-valued shadowing local in `Bootstrap.get_samples`.
- **Housekeeping**: fixes were folded into their original commits by concern rather than appended as a fixup — `perf(probabilistic): vectorize Bootstrap.get_samples reconciliation`, `perf(probabilistic): vectorize PERMBU rank computation`, `perf(methods): avoid densifying S in _get_child_nodes`, `test: add regression tests and benchmarks for perf fixes`, plus a new `ci: exclude benchmarks from wheel test matrix` commit for the CI-only change.

## Testing

- `git submodule update --init --recursive`, then `uv sync` (built the pybind11/Eigen C++ extension successfully; see note below).
- Ran the specific affected test files:
  - `tests/test_probabilistic_methods.py` — **53 passed** (includes the new `TestBootstrapVectorization`/`TestPermbuObtainRanksVectorization` cases plus the post-review `num_samples=1`/`h=1` edge case)
  - `tests/test_methods.py` — **133 passed** (includes `TestGetChildNodes`, plus the post-review singleton-child-parent case, plus the deterministic-seed fuzz test)
  - `tests/test_benchmarks.py` — **17 passed** with `-m benchmark --benchmark-disable` (functional correctness, not timing); `-m benchmark --collect-only` collects all 17, `-m "not benchmark" --collect-only` collects 0 from this file, confirming the CI marker filter works as intended.
- Added regression tests reimplementing the pre-optimization logic inline and asserting equivalence:
  - `TestBootstrapVectorization` — `np.testing.assert_allclose` (dense and sparse `S`/`P`, plus a dedicated degenerate `num_samples=1`/`h=1` case)
  - `TestPermbuObtainRanksVectorization` — `np.testing.assert_array_equal` (exact), including a tie-breaking case, parametrized over several shapes
  - `TestGetChildNodes` — exact structural/order equality against the reference dense implementation, including a fuzz test over random multi-level hierarchies with shuffled tag ordering (both dense and sparse `S`, now with a deterministic `crc32`-derived seed instead of `hash()`), and a hand-written hierarchy that forces a singleton-child parent
- Full-suite run in this sandbox (`tests/`, excluding benchmarks) hits network-dependent fixtures (`tourism_df` et al. fetch a CSV from `raw.githubusercontent.com`, which this particular sandbox can't reach) that error out unrelated to this change — same failures exist on `main`. The files this PR actually touches (`test_probabilistic_methods.py`, `test_methods.py`, `test_benchmarks.py`) have no such network dependency and all pass cleanly as reported above.
- `ruff check` passes clean on every file touched by this PR, including the new `conftest.py` additions and the CI/`pyproject.toml` changes. `ruff format --check`: `test_benchmarks.py` is kept format-clean (it already was on `main`, and stayed that way through the post-review edits — line-wrapped the one call that got too long); the other four touched Python files (`probabilistic_methods.py`, `methods.py`, `test_methods.py`, `test_probabilistic_methods.py`, `conftest.py`) were already not `ruff format`-clean on `main` before this branch, and this PR doesn't newly introduce that — left as-is rather than mixing an unrelated repo-wide reformat into a perf/test PR.

### Build note (environment-specific, not a code issue)

Building the C++ extension locally required working around a local toolchain quirk: this machine is arm64 but its only Homebrew install is the x86_64-prefix one, so `brew --prefix libomp` resolved to an x86_64-only `libomp.dylib`/`omp.h`, and the resulting universal2 build's arm64 slice silently linked with no OpenMP symbols at all, then failed at import with `symbol not found in flat namespace '__kmpc_dispatch_deinit'` once an arm64 `libomp` was substituted from an older bundled copy. Fixed locally by pulling the current arm64 `libomp` Homebrew bottle directly and building `ARCHFLAGS="-arch arm64"`-only. This is purely a local dev-environment issue on this particular machine (mismatched Homebrew prefix vs. host architecture) and isn't something this PR needs to address in `setup.py`.
