### PR TITLE
perf: matrix-free kronecker lasso for erm reconciliation

### DIFF
--- a/hierarchicalforecast/methods.py
+++ b/hierarchicalforecast/methods.py
@@ -14,7 +14,7 @@ from scipy import sparse
 from hierarchicalforecast.utils import (
     _construct_adjacency_matrix,
     _is_strictly_hierarchical,
-    _lasso,
+    _lasso_kron,
     _ma_cov,
     _shrunk_covariance_schaferstrimmer_no_nans,
     _shrunk_covariance_schaferstrimmer_with_nans,
@@ -2041,6 +2041,11 @@ class ERM(HReconciler):
         y_insample: np.ndarray,
         y_hat_insample: np.ndarray,
     ):
+        if sparse.issparse(S):
+            # S is the small Kronecker factor (n_hiers, n_bottom); every ERM
+            # variant needs it dense, so densify it here. The insample
+            # matrices dominate memory, not S.
+            S = S.toarray()
         n_hiers, n_bottom = S.shape
         # y_hat_insample shape (n_hiers, obs)
         if y_insample is None or y_hat_insample is None:
@@ -2071,28 +2076,43 @@ class ERM(HReconciler):
             P = np.linalg.pinv(y_hat_insample.T) @ B
             P = P.T
         elif self.method == "reg":
-            X = np.kron(S, y_hat_insample.T)
+            # The Lasso design matrix X = np.kron(S, y_hat_insample.T) has
+            # shape (n_hiers * h, n_bottom * n_hiers), i.e.
+            # O(n_hiers^2 * n_bottom * h) memory, which OOMs for a few
+            # thousand series. `_lasso_kron` runs the same cyclic coordinate
+            # descent directly on the Kronecker factors S and Y, so X is
+            # never materialized. Column j = j1 * n_hiers + j2 of X equals
+            # np.kron(S[:, j1], Y[:, j2]).
+            Y = y_hat_insample.T
             z = y_insample.reshape(-1)
 
             if self.lambda_reg is None:
-                lambda_reg = np.max(np.abs(X.T.dot(z)))
+                # max |X.T @ z|: (X.T @ z)[j1 * n_hiers + j2]
+                # = S[:, j1] @ y_insample @ Y[:, j2]
+                lambda_reg = np.max(np.abs(S.T @ y_insample @ Y))
             else:
                 lambda_reg = self.lambda_reg
 
-            beta = _lasso(X, z, lambda_reg, max_iters=1000, tol=1e-4)
+            beta = _lasso_kron(S, Y, z, lambda_reg, max_iters=1000, tol=1e-4)
             P = beta.reshape(S.shape).T
         elif self.method == "reg_bu":
-            X = np.kron(S, y_hat_insample.T)
+            Y = y_hat_insample.T
             Pbu = np.zeros_like(S)
             Pbu[idx_bottom] = S[idx_bottom]
-            z = y_insample.reshape(-1) - X @ Pbu.reshape(-1)
+            # X @ Pbu.reshape(-1) with X = np.kron(S, Y): grouping the flat
+            # index as j = j1 * n_hiers + j2 gives V[j1, j2] = Pbu.flat[j]
+            # and (X @ Pbu.reshape(-1)).reshape(n_hiers, h) = S @ V @ Y.T,
+            # with Y.T = y_hat_insample.
+            V = Pbu.reshape(n_bottom, n_hiers)
+            z = (y_insample - S @ V @ y_hat_insample).reshape(-1)
 
             if self.lambda_reg is None:
-                lambda_reg = np.max(np.abs(X.T.dot(z)))
+                # max |X.T @ z| via the Kronecker factors (see `reg` above)
+                lambda_reg = np.max(np.abs(S.T @ z.reshape(n_hiers, -1) @ Y))
             else:
                 lambda_reg = self.lambda_reg
 
-            beta = _lasso(X, z, lambda_reg, max_iters=1000, tol=1e-4)
+            beta = _lasso_kron(S, Y, z, lambda_reg, max_iters=1000, tol=1e-4)
             P = beta + Pbu.reshape(-1)
             P = P.reshape(S.shape).T
         else:

--- a/hierarchicalforecast/utils.py
+++ b/hierarchicalforecast/utils.py
@@ -1034,6 +1034,34 @@ def _lasso(
     return _lib_recon._lasso(np.asfortranarray(X), y, lambda_reg, max_iters, tol)
 
 
+# Matrix-free Lasso for X = np.kron(S, Y)
+def _lasso_kron(
+    S: np.ndarray,
+    Y: np.ndarray,
+    y: np.ndarray,
+    lambda_reg: float,
+    max_iters: int = 1_000,
+    tol: float = 1e-4,
+):
+    """Matrix-free Lasso cyclic coordinate descent for X = np.kron(S, Y).
+
+    :meta private:
+    """
+    # Unlike `_lasso` above, which relies on pybind11's implicit copy to
+    # coerce its input, the dtype/order coercion here is explicit: S and Y
+    # are the small Kronecker factors, so casting them up front is cheap and
+    # gives a clear error if a sparse S slips through instead of a mismatched
+    # pybind11 overload error.
+    return _lib_recon._lasso_kron(
+        np.asfortranarray(S, dtype=np.float64),
+        np.asfortranarray(Y, dtype=np.float64),
+        np.ascontiguousarray(y, dtype=np.float64),
+        lambda_reg,
+        max_iters,
+        tol,
+    )
+
+
 class SMatrix:
     """Lightweight wrapper around a scipy.sparse summing matrix with labels.
 

--- a/src/reconciliation.cpp
+++ b/src/reconciliation.cpp
@@ -1,6 +1,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <pybind11/eigen.h>
@@ -361,6 +364,119 @@ VectorXd lasso(const Eigen::Ref<const MatrixXd> &X,
   return beta;
 }
 
+// ---------- _lasso_kron ----------
+// Matrix-free Lasso cyclic coordinate descent for X = np.kron(S, Y).
+// Numerically equivalent to lasso(np.kron(S, Y), y, ...) without ever
+// materializing X, which has shape (S.rows()*Y.rows(), S.cols()*Y.cols())
+// and therefore O(n_hiers^2 * n_bottom * h) memory.
+//
+// np.kron layout: X[i1*h + i2, j1*n_y + j2] = S(i1, j1) * Y(i2, j2), so
+// column j = j1*n_y + j2 of X equals kron(S.col(j1), Y.col(j2)). Every
+// quantity the dense kernel needs factors through S and Y:
+//   X.col(j).squaredNorm() = ||S.col(j1)||^2 * ||Y.col(j2)||^2
+//   X.col(j).dot(r)        = sum_i1 S(i1,j1) * Y.col(j2).dot(r.segment(i1*h, h))
+//   r += a * X.col(j)      -> r.segment(i1*h, h) += a * S(i1,j1) * Y.col(j2)
+// Zero entries of S.col(j1) (summing matrices are mostly zeros) contribute
+// exactly zero to the sums above and are skipped, so each coordinate update
+// costs O(nnz(S.col(j1)) * h) instead of O(n_hiers * h).
+//
+// Iteration order, convergence criterion, soft-threshold formula and the
+// column-norm skip guard mirror lasso() exactly; only the summations are
+// reassociated, so results match the dense kernel to floating-point
+// round-off (see tests/test_methods.py equivalence tests).
+// S: (n_hiers, n_bottom) column-major float64
+// Y: (h, n_hiers) column-major float64 (y_hat_insample transposed)
+// y: (n_hiers * h,) float64 target
+// Returns: (n_bottom * n_hiers,) float64 beta coefficients
+VectorXd lasso_kron(const Eigen::Ref<const MatrixXd> &S,
+                    const Eigen::Ref<const MatrixXd> &Y,
+                    const Eigen::Ref<const VectorXd> &y, double lambda_reg,
+                    int64_t max_iters, double tol) {
+  const Eigen::Index n_rows_s = S.rows();
+  const Eigen::Index n_cols_s = S.cols();
+  const Eigen::Index h = Y.rows();
+  const Eigen::Index n_cols_y = Y.cols();
+  const Eigen::Index n = n_rows_s * h;         // rows of the implicit X
+  const Eigen::Index feats = n_cols_s * n_cols_y; // cols of the implicit X
+
+  if (n_rows_s != n_cols_y) {
+    throw std::invalid_argument("S.rows() must equal Y.cols()");
+  }
+  if (y.size() != n) {
+    throw std::invalid_argument(
+        "y must have S.rows() * Y.rows() elements to match kron(S, Y)");
+  }
+
+  // Sparsity pattern of each S column: summing matrices are 0/1 with
+  // O(depth) nonzeros per column, so this collapses the per-coordinate
+  // cost from O(n_hiers * h) to O(depth * h).
+  std::vector<std::vector<std::pair<Eigen::Index, double>>> s_nonzeros(
+      n_cols_s);
+  for (Eigen::Index j1 = 0; j1 < n_cols_s; ++j1) {
+    for (Eigen::Index i1 = 0; i1 < n_rows_s; ++i1) {
+      const double v = S(i1, j1);
+      if (v != 0.0) {
+        s_nonzeros[j1].emplace_back(i1, v);
+      }
+    }
+  }
+
+  // Column norms of the implicit X factor through the Kronecker product.
+  const VectorXd s_norms = S.colwise().squaredNorm();
+  const VectorXd y_norms = Y.colwise().squaredNorm();
+
+  VectorXd beta = VectorXd::Zero(feats);
+  VectorXd beta_changes = VectorXd::Zero(feats);
+  VectorXd residuals = y; // copy
+
+  for (int64_t it = 0; it < max_iters; ++it) {
+    for (Eigen::Index j1 = 0; j1 < n_cols_s; ++j1) {
+      const auto &nz = s_nonzeros[j1];
+      const double s_norm_j1 = s_norms(j1);
+      for (Eigen::Index j2 = 0; j2 < n_cols_y; ++j2) {
+        // Same coordinate order as the dense kernel: i = j1 * n_cols_y + j2
+        const Eigen::Index i = j1 * n_cols_y + j2;
+        // Product of the two factor norms vs. the dense kernel's single
+        // reduction over the materialized column: can differ by ~1 ulp right
+        // at the 1e-8 boundary. Accepted, same reassociation class documented
+        // in the function comment above.
+        const double norms_i = s_norm_j1 * y_norms(j2);
+        if (norms_i < 1e-8)
+          continue;
+
+        const double inv_norms_i = 1.0 / norms_i;
+
+        // X.col(i).dot(residuals) via the Kronecker factors
+        double dot = 0.0;
+        for (const auto &[i1, s_val] : nz) {
+          dot += s_val * Y.col(j2).dot(residuals.segment(i1 * h, h));
+        }
+        const double rho = beta(i) + dot * inv_norms_i;
+
+        // Soft threshold (identical to lasso())
+        const double threshold = lambda_reg * n * inv_norms_i;
+        const double sign_rho = (rho > 0.0) ? 1.0 : ((rho < 0.0) ? -1.0 : 0.0);
+        const double beta_i_next =
+            sign_rho * std::max(std::abs(rho) - threshold, 0.0);
+        const double beta_delta = beta(i) - beta_i_next;
+        beta_changes(i) = std::abs(beta_delta);
+
+        if (beta_delta != 0.0) {
+          // residuals += beta_delta * X.col(i) via the Kronecker factors
+          for (const auto &[i1, s_val] : nz) {
+            residuals.segment(i1 * h, h).noalias() +=
+                (beta_delta * s_val) * Y.col(j2);
+          }
+          beta(i) = beta_i_next;
+        }
+      }
+    }
+    if (beta_changes.maxCoeff() < tol)
+      break;
+  }
+  return beta;
+}
+
 // ---------- Module init ----------
 void init(py::module_ &m) {
   py::module_ recon = m.def_submodule("reconciliation");
@@ -377,6 +493,9 @@ void init(py::module_ &m) {
             py::call_guard<py::gil_scoped_release>());
   recon.def("_lasso", &lasso, py::arg("X"), py::arg("y"),
             py::arg("lambda_reg"), py::arg("max_iters") = 1000,
+            py::arg("tol") = 1e-4, py::call_guard<py::gil_scoped_release>());
+  recon.def("_lasso_kron", &lasso_kron, py::arg("S"), py::arg("Y"),
+            py::arg("y"), py::arg("lambda_reg"), py::arg("max_iters") = 1000,
             py::arg("tol") = 1e-4, py::call_guard<py::gil_scoped_release>());
 }
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -3,6 +3,7 @@ import pytest
 
 from hierarchicalforecast.utils import (
     _lasso,
+    _lasso_kron,
     _ma_cov,
     _shrunk_covariance_schaferstrimmer_no_nans,
     _shrunk_covariance_schaferstrimmer_with_nans,
@@ -45,3 +46,40 @@ def lasso_data():
 def test_bench_lasso(benchmark, lasso_data):
     X, y = lasso_data
     benchmark(_lasso, X, y, 0.1, 1000, 1e-4)
+
+
+@pytest.fixture
+def lasso_kron_data():
+    """Kronecker factors shaped like the ERM reg/reg_bu design matrix.
+
+    S is a summing-matrix-like factor (total + 5 groups + identity) and Y is
+    the transposed insample forecast matrix; the implicit design matrix
+    X = np.kron(S, Y) has shape (n_hiers * h, n_bottom * n_hiers).
+    """
+    rng = np.random.default_rng(42)
+    n_bottom, h = 50, 8
+    S = np.vstack(
+        [
+            np.ones((1, n_bottom)),
+            np.repeat(np.eye(5), n_bottom // 5, axis=1),
+            np.eye(n_bottom),
+        ]
+    )
+    Y = rng.standard_normal((h, S.shape[0]))
+    y = rng.standard_normal(S.shape[0] * h)
+    return S, Y, y
+
+
+def test_bench_lasso_kron(benchmark, lasso_kron_data):
+    S, Y, y = lasso_kron_data
+    benchmark(_lasso_kron, S, Y, y, 0.1, 1000, 1e-4)
+
+
+def test_bench_lasso_kron_materialized_baseline(benchmark, lasso_kron_data):
+    """Old ERM path: materialize np.kron(S, Y), then run the dense Lasso."""
+    S, Y, y = lasso_kron_data
+
+    def _materialized():
+        return _lasso(np.kron(S, Y), y, 0.1, 1000, 1e-4)
+
+    benchmark(_materialized)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -719,7 +719,8 @@ def test_optimal_combination_works_with_grouped_hierarchy(common_test_data, meth
 def test_erm_works_with_grouped_hierarchy(common_test_data):
     """Test that ERM works correctly with grouped data.
 
-    Note: Only testing 'closed' method as 'reg' and 'reg_bu' are computationally expensive.
+    Note: Only testing 'closed' method here; 'reg' and 'reg_bu' on this same
+    grouped hierarchy are covered by test_erm_lasso_methods_work_through_reconcile.
     """
     data = common_test_data["grouped"]
     Y_hat, Y_train, S, tags = data["Y_hat_df"], data["Y_train_df"], data["S_df"], data["tags"]
@@ -734,6 +735,28 @@ def test_erm_works_with_grouped_hierarchy(common_test_data):
     assert reconciled is not None
     expected_col = f'y_model/ERM_method-{method}_lambda_reg-0.01'
     assert expected_col in reconciled.columns
+
+
+@pytest.mark.parametrize("method", ["reg", "reg_bu"])
+@pytest.mark.parametrize("hierarchy", ["strict", "grouped"])
+def test_erm_lasso_methods_work_through_reconcile(common_test_data, hierarchy, method):
+    """Test ERM reg/reg_bu end to end through the public reconcile API.
+
+    These methods run the matrix-free Kronecker Lasso; before that kernel the
+    materialized np.kron design matrix made them too expensive to test here,
+    especially on the full grouped hierarchy (425 series, 304 bottom).
+    """
+    data = common_test_data[hierarchy]
+    Y_hat, Y_train, S, tags = data["Y_hat_df"], data["Y_train_df"], data["S_df"], data["tags"]
+
+    reconciler = ERM(method=method, lambda_reg=1e-2)
+    hrec = HierarchicalReconciliation([reconciler])
+
+    reconciled = hrec.reconcile(Y_hat_df=Y_hat, Y_df=Y_train, S_df=S, tags=tags)
+
+    expected_col = f'y_model/ERM_method-{method}_lambda_reg-0.01'
+    assert expected_col in reconciled.columns
+    assert not reconciled[expected_col].isna().any()
 
 
 # Tests for methods that require strictly hierarchical structures working with strict data

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -17,7 +17,11 @@ from hierarchicalforecast.methods import (
     _is_strictly_hierarchical,
     is_strictly_hierarchical,
 )
-from hierarchicalforecast.utils import _construct_adjacency_matrix
+from hierarchicalforecast.utils import (
+    _construct_adjacency_matrix,
+    _lasso,
+    _lasso_kron,
+)
 
 
 @dataclass
@@ -510,6 +514,168 @@ def test_erm_forecast_recovery(hierarchical_data):
     )["mean"]
 
     np.testing.assert_allclose(result, data.S @ data.y_hat_bottom)
+
+
+def _summing_matrix_from_groups(rng, n_bottom, n_extra_agg_rows):
+    """Build a summing-matrix-like S: total + random aggregates + identity."""
+    rows = [np.ones((1, n_bottom))]
+    for _ in range(n_extra_agg_rows):
+        rows.append(rng.integers(0, 2, (1, n_bottom)).astype(np.float64))
+    rows.append(np.eye(n_bottom))
+    return np.vstack(rows)
+
+
+@pytest.mark.parametrize(
+    "n_bottom,n_extra_agg_rows,h",
+    [
+        (1, 0, 1),  # single bottom series, single step
+        (1, 0, 4),  # single bottom series
+        (4, 0, 1),  # single step horizon
+        (4, 0, 3),  # total + identity only (single-level)
+        (5, 2, 4),  # grouped aggregates
+        (8, 3, 6),  # deeper hierarchy
+    ],
+)
+def test_lasso_kron_matches_materialized_kron(n_bottom, n_extra_agg_rows, h):
+    """_lasso_kron(S, Y, y) must match _lasso(np.kron(S, Y), y) to round-off.
+
+    The matrix-free kernel performs the same cyclic coordinate descent with
+    the same iteration order, soft-threshold formula and convergence
+    criterion; only the summations are reassociated through the Kronecker
+    factors, so results agree to floating-point round-off.
+    """
+    rng = np.random.default_rng(n_bottom * 100 + n_extra_agg_rows * 10 + h)
+    S = _summing_matrix_from_groups(rng, n_bottom, n_extra_agg_rows)
+    n_hiers = S.shape[0]
+    Y = rng.standard_normal((h, n_hiers))
+    y = rng.standard_normal(n_hiers * h)
+    for lambda_reg in (1e-3, 1e-1):
+        beta_dense = _lasso(np.kron(S, Y), y, lambda_reg, max_iters=1000, tol=1e-4)
+        beta_free = _lasso_kron(S, Y, y, lambda_reg, max_iters=1000, tol=1e-4)
+        np.testing.assert_allclose(beta_free, beta_dense, rtol=1e-8, atol=1e-11)
+
+
+def test_lasso_kron_fuzz_random_shapes():
+    """Fuzz _lasso_kron vs the materialized-kron path over random shapes."""
+    rng = np.random.default_rng(0)
+    for _ in range(25):
+        n_bottom = int(rng.integers(1, 9))
+        n_extra_agg_rows = int(rng.integers(0, 4))
+        h = int(rng.integers(1, 8))
+        S = _summing_matrix_from_groups(rng, n_bottom, n_extra_agg_rows)
+        n_hiers = S.shape[0]
+        Y = rng.standard_normal((h, n_hiers))
+        y = rng.standard_normal(n_hiers * h)
+        lambda_reg = 10.0 ** rng.uniform(-4, 0)
+        beta_dense = _lasso(np.kron(S, Y), y, lambda_reg, max_iters=1000, tol=1e-4)
+        beta_free = _lasso_kron(S, Y, y, lambda_reg, max_iters=1000, tol=1e-4)
+        np.testing.assert_allclose(beta_free, beta_dense, rtol=1e-8, atol=1e-11)
+
+
+def test_lasso_kron_validates_target_length():
+    """_lasso_kron rejects a target that does not match kron(S, Y) rows."""
+    rng = np.random.default_rng(42)
+    S = _summing_matrix_from_groups(rng, 3, 0)
+    Y = rng.standard_normal((2, S.shape[0]))
+    with pytest.raises(ValueError, match="S.rows"):
+        _lasso_kron(S, Y, np.zeros(5), 1e-2)
+
+
+def test_lasso_kron_validates_kronecker_shapes():
+    """_lasso_kron rejects S/Y whose Kronecker shapes don't line up.
+
+    S.rows() indexes the hierarchy and must match Y.cols(); a mismatch would
+    silently pair the wrong rows of S with the wrong columns of Y.
+    """
+    rng = np.random.default_rng(7)
+    S = _summing_matrix_from_groups(rng, 3, 0)
+    n_hiers = S.shape[0]
+    Y = rng.standard_normal((2, n_hiers + 1))  # Y.cols() != S.rows()
+    y = rng.standard_normal(n_hiers * 2)
+    with pytest.raises(ValueError, match="S.rows.*Y.cols"):
+        _lasso_kron(S, Y, y, 1e-2)
+
+
+def test_lasso_kron_zeroed_column_matches_materialized_kron():
+    """A zeroed Y column drives norms_i below the 1e-8 skip guard.
+
+    Regression case for the skip guard in `lasso_kron`: when an entire Y
+    column is zero, `s_norm_j1 * y_norms(j2)` is exactly 0 for every j1 at
+    that j2, so the coordinate is skipped for every S column. The matrix-free
+    kernel must still match the materialized path exactly in that regime.
+    """
+    rng = np.random.default_rng(123)
+    n_bottom, n_extra_agg_rows, h = 5, 2, 4
+    S = _summing_matrix_from_groups(rng, n_bottom, n_extra_agg_rows)
+    n_hiers = S.shape[0]
+    Y = rng.standard_normal((h, n_hiers))
+    Y[:, 0] = 0.0  # zero out one full column -> norms_i < 1e-8 for j2=0
+    y = rng.standard_normal(n_hiers * h)
+    for lambda_reg in (1e-3, 1e-1):
+        beta_dense = _lasso(np.kron(S, Y), y, lambda_reg, max_iters=1000, tol=1e-4)
+        beta_free = _lasso_kron(S, Y, y, lambda_reg, max_iters=1000, tol=1e-4)
+        np.testing.assert_allclose(beta_free, beta_dense, rtol=1e-8, atol=1e-11)
+
+
+def _erm_pw_materialized_kron(S, y_hat, y_insample, y_hat_insample, method, lambda_reg):
+    """Reference implementation: the pre-matrix-free ERM reg/reg_bu path."""
+    n_hiers, n_bottom = S.shape
+    idx_bottom = list(range(n_hiers - n_bottom, n_hiers))
+    h = min(y_hat.shape[1], y_hat_insample.shape[1])
+    y_hat_insample = y_hat_insample[:, -h:]
+    y_insample = y_insample[:, -h:]
+    X = np.kron(S, y_hat_insample.T)
+    if method == "reg":
+        z = y_insample.reshape(-1)
+        lam = np.max(np.abs(X.T.dot(z))) if lambda_reg is None else lambda_reg
+        beta = _lasso(X, z, lam, max_iters=1000, tol=1e-4)
+        P = beta.reshape(S.shape).T
+    else:
+        Pbu = np.zeros_like(S)
+        Pbu[idx_bottom] = S[idx_bottom]
+        z = y_insample.reshape(-1) - X @ Pbu.reshape(-1)
+        lam = np.max(np.abs(X.T.dot(z))) if lambda_reg is None else lambda_reg
+        beta = _lasso(X, z, lam, max_iters=1000, tol=1e-4)
+        P = (beta + Pbu.reshape(-1)).reshape(S.shape).T
+    return P
+
+
+@pytest.mark.parametrize("method", ["reg", "reg_bu"])
+@pytest.mark.parametrize("lambda_reg", [1e-2, None])
+def test_erm_reg_matches_materialized_kron(hierarchical_data, method, lambda_reg):
+    """ERM reg/reg_bu must reproduce the old np.kron + _lasso path."""
+    data = hierarchical_data
+    S = data.S
+    y_hat = S @ data.y_hat_bottom
+    y_insample = S @ data.y_bottom
+    y_hat_insample = S @ np.nan_to_num(data.y_hat_bottom_insample, nan=1.0)
+
+    P_expected = _erm_pw_materialized_kron(
+        S, y_hat, y_insample, y_hat_insample, method, lambda_reg
+    )
+    P_actual, W = ERM(method=method, lambda_reg=lambda_reg)._get_PW_matrices(
+        S, y_hat, y_insample, y_hat_insample
+    )
+    np.testing.assert_allclose(P_actual, P_expected, rtol=1e-8, atol=1e-11)
+    np.testing.assert_array_equal(W, np.eye(S.shape[0]))
+
+
+@pytest.mark.parametrize("method", ["closed", "reg", "reg_bu"])
+def test_erm_accepts_sparse_S(hierarchical_data, method):
+    """ERM densifies a sparse summing matrix and matches the dense result."""
+    data = hierarchical_data
+    S = data.S
+    y_hat = S @ data.y_hat_bottom
+    y_insample = S @ data.y_bottom
+    y_hat_insample = S @ np.nan_to_num(data.y_hat_bottom_insample, nan=1.0)
+
+    P_dense, _ = ERM(method=method, lambda_reg=1e-2)._get_PW_matrices(
+        S, y_hat, y_insample, y_hat_insample
+    )
+    P_sparse, _ = ERM(method=method, lambda_reg=1e-2)._get_PW_matrices(
+        sparse.csr_matrix(S), y_hat, y_insample, y_hat_insample
+    )
+    np.testing.assert_allclose(P_sparse, P_dense, rtol=1e-12, atol=0)
 
 
 @pytest.fixture


### PR DESCRIPTION

## What

`ERM(method="reg")` and `ERM(method="reg_bu")` no longer materialize the Lasso design matrix `X = np.kron(S, y_hat_insample.T)`. A new C++ kernel (`_lasso_kron`, alongside the existing `_lasso` in `src/reconciliation.cpp`) runs the same cyclic coordinate descent directly on the Kronecker factors `S` (`n_hiers x n_bottom`) and `Y = y_hat_insample.T` (`h x n_hiers`).

### Why: the memory math

`X` has shape `(n_hiers * h, n_bottom * n_hiers)`:

- **Old:** `8 * n_hiers^2 * n_bottom * h` bytes for `X`, and the `_lasso` wrapper's `np.asfortranarray(X)` copies it again, so peak is ~**2x** that.
- **New:** `O(n_hiers * n_bottom + n_hiers * h)` — just the factors plus a residual vector.

Concrete sizes at `h = 12`:

| Hierarchy | `X` alone | Old peak (`X` + F-order copy) | New extra memory |
| --- | --- | --- | --- |
| Australian tourism, grouped (425 series, 304 bottom) | 4.9 GiB | ~9.8 GiB | ~1 MiB |
| 2,000 series, 1,500 bottom | 536 GiB | ~1.05 TiB | ~24 MiB |

The quadratic-in-`n_hiers` term is gone entirely. (The existing cap of insample steps at `h` "to avoid computational burden" is preserved unchanged, so results are identical; with the new kernel that cap could arguably be relaxed in a follow-up.)

## How

`np.kron` layout: `X[i1*h + i2, j1*n_hiers + j2] = S[i1, j1] * Y[i2, j2]`. Grouping the column index as `j = j1 * n_hiers + j2` gives

```
X[:, j] = np.kron(S[:, j1], Y[:, j2])
```

so every quantity the coordinate-descent kernel needs factors through `S` and `Y`:

- column norms: `||X[:, j]||^2 = ||S[:, j1]||^2 * ||Y[:, j2]||^2`
- residual dot: `X[:, j] . r = sum_i1 S[i1, j1] * (Y[:, j2] . r[i1*h : (i1+1)*h])`
- update: `r += a * X[:, j]`  ->  `r[i1*h : (i1+1)*h] += a * S[i1, j1] * Y[:, j2]`

Zero entries of `S[:, j1]` contribute exactly zero to these sums and are skipped; summing-matrix columns have only `O(depth)` nonzeros, so each coordinate update also drops from `O(n_hiers * h)` to `O(depth * h)` flops on top of the memory win.

The same identities remove the remaining `X` uses in `ERM._get_PW_matrices`:

- `reg_bu`'s `X @ Pbu.reshape(-1)` becomes `S @ Pbu.reshape(n_bottom, n_hiers) @ y_hat_insample` (the flat index regrouped as `V[j1, j2] = Pbu.flat[j1*n_hiers + j2]`),
- `lambda_reg=None`'s `max |X.T @ z|` becomes `max |S.T @ Z @ Y|` with `Z = z.reshape(n_hiers, h)`.

`ERM._get_PW_matrices` now also accepts a sparse `S`, densified up front (`S` is the small factor). `np.kron` itself does not raise on a sparse `S` — it silently returns an object-dtype array of sparse-matrix blocks — so the previous code failed downstream instead: `TypeError` in `_lasso` (pybind11 rejects the object dtype), `ValueError` in the `lambda_reg=None` bound for `reg`/`reg_bu` (`X.T @ z` on the object array), and `LinAlgError` in `np.linalg.inv` for `closed`. Densifying `S` up front fixes all three at the source, a strict capability improvement rather than a workaround for one specific failure mode.

### Equivalence strategy

`_lasso_kron` mirrors `_lasso` exactly: same coordinate iteration order (`j = j1 * n_hiers + j2` ascending), same soft-threshold formula, same `norms < 1e-8` skip guard, same `max|delta beta| < tol` convergence criterion, same `max_iters`/`tol` defaults. The only difference is that the reductions are computed through the Kronecker factors, i.e. identical arithmetic reassociated. **Achieved equivalence level: floating-point round-off (allclose), not bit-equality** — reassociating the reductions necessarily changes rounding order. Measured against the materialized `np.kron` + `_lasso` path:

- kernel fuzzing over shapes (including `n_bottom=1`, single-level, `h=1`): max abs deviation ~2e-14
- full `_get_PW_matrices` at 181 series x 150 bottom, h=12: max abs deviation ~3e-13

Tests assert `rtol=1e-8, atol=1e-11`.

## Benchmarks (Apple M-series, single thread)

`pytest-benchmark`, `tests/test_benchmarks.py`, implicit `X` of 448 x 2,800 (56-series hierarchy, 50 bottom, h=8):

| Benchmark | Median | Speedup |
| --- | --- | --- |
| `test_bench_lasso_kron_materialized_baseline` (old: `np.kron` + `_lasso`) | 2,446 us | 1x |
| `test_bench_lasso_kron` (new, matrix-free) | 37.1 us | **66x** |

End-to-end `ERM._get_PW_matrices` (both Lasso methods), peak RSS via `ru_maxrss`, each path in a fresh process:

**Australian tourism grouped hierarchy (425 series, 304 bottom, h=12)** — `X` is 5,100 x 129,200 = 4.91 GiB:

| Path | reg | reg_bu | Peak RSS |
| --- | --- | --- | --- |
| Old (`np.kron` + `_lasso`) | 484.9 s | 315.3 s | 9.97 GiB |
| New (`_lasso_kron`) | 9.9 s (**49x**) | 8.8 s (**36x**) | **0.29 GiB** (34x less) |

**Mid-scale synthetic (181 series, 150 bottom, h=12)** — `X` is 2,172 x 27,150 = 0.44 GiB:

| Path | reg | reg_bu |
| --- | --- | --- |
| Old | 30.8 s | 31.8 s |
| New | 0.9 s (**34x**) | 1.5 s (**21x**) |

**Capability unlock — 2,000-series hierarchy (1,500 bottom, 3 aggregation levels, h=12):** the old path must allocate a 24,000 x 3,000,000 design matrix: **536 GiB for `X` plus an equal-size F-order copy (~1.05 TiB peak)**, far beyond the 64 GiB test machine — it cannot run at all. The new path:

| Path | reg | reg_bu | Peak RSS |
| --- | --- | --- | --- |
| New (`_lasso_kron`) | 58.5 s | 92.9 s | **0.41 GiB** |

## Testing

- `tests/test_methods.py`:
  - `test_lasso_kron_matches_materialized_kron` — parametrized over edge shapes (`n_bottom=1`, `h=1`, single-level, grouped, deep) x two lambdas, asserts the matrix-free kernel matches `_lasso(np.kron(S, Y), ...)` at `rtol=1e-8, atol=1e-11`.
  - `test_lasso_kron_fuzz_random_shapes` — 25 randomized shape/lambda configs against the materialized path.
  - `test_lasso_kron_validates_target_length` — input validation on `y`'s length.
  - `test_lasso_kron_validates_kronecker_shapes` — input validation on `S.rows() == Y.cols()`.
  - `test_lasso_kron_zeroed_column_matches_materialized_kron` — a zeroed `Y` column drives `norms_i` below the `1e-8` skip guard for every `S` column at that coordinate; still matches the materialized path.
  - `test_erm_reg_matches_materialized_kron` — `reg`/`reg_bu` x `lambda_reg in {1e-2, None}`: `ERM._get_PW_matrices` vs an inline re-implementation of the old materialized path.
  - `test_erm_accepts_sparse_S` — `closed`/`reg`/`reg_bu` with a `csr_matrix` summing matrix match the dense results.
- `tests/test_core.py`: `test_erm_lasso_methods_work_through_reconcile` — `reg`/`reg_bu` end to end through the public `HierarchicalReconciliation.reconcile` API, parametrized over both the tourism strict hierarchy and the full grouped hierarchy (425 series, 304 bottom) — previously only `closed` was tested on the grouped hierarchy, and `reg`/`reg_bu` weren't tested through `reconcile` at all, because the materialized path was too expensive.
- `tests/test_benchmarks.py`: `test_bench_lasso_kron` + `test_bench_lasso_kron_materialized_baseline`, following the file's existing fixture/bench patterns (no markers, consistent with main's current state). Note: #494 also touches `tests/test_benchmarks.py`, so whichever lands second has a small, mechanical merge overlap in this file.
- Full suites green locally: `tests/test_methods.py` (137), `tests/test_core.py` (76), `tests/test_utils.py` (20), `tests/test_probabilistic_methods.py` + `tests/test_evaluation.py` + `tests/test_diagnostics.py` (65), `tests/test_benchmarks.py` lasso benches.
