### PR TITLE
perf: native batched forecast-proportions traversal (stacked on #494)

### DIFF
--- a/hierarchicalforecast/methods.py
+++ b/hierarchicalforecast/methods.py
@@ -11,6 +11,7 @@ import numpy as np
 from qpsolvers import solve_qp
 from scipy import sparse
 
+from hierarchicalforecast._lib import reconciliation as _lib_recon
 from hierarchicalforecast.utils import (
     _construct_adjacency_matrix,
     _is_strictly_hierarchical,
@@ -392,6 +393,93 @@ def _get_child_nodes(
     return nodes
 
 
+def _flatten_child_nodes(
+    nodes: dict[str, dict[int, np.ndarray]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Flatten `_get_child_nodes` output into CSR-style int64 arrays.
+
+    Returns `(parent_idx, child_indptr, child_idx)` where parents appear in
+    traversal order (levels top-to-bottom, insertion order within each level)
+    and `child_idx[child_indptr[p]:child_indptr[p + 1]]` are the children of
+    node `parent_idx[p]`, preserving the exact ordering the pure-Python
+    reference `_reconcile_fcst_proportions` iterates in.
+    """
+    parent_idx: list[int] = []
+    child_indptr: list[int] = [0]
+    child_idx: list[int] = []
+    for nodes_level in nodes.values():
+        for idx_parent, idx_childs in nodes_level.items():
+            parent_idx.append(idx_parent)
+            child_idx.extend(idx_childs)
+            child_indptr.append(len(child_idx))
+    return (
+        np.asarray(parent_idx, dtype=np.int64),
+        np.asarray(child_indptr, dtype=np.int64),
+        np.asarray(child_idx, dtype=np.int64),
+    )
+
+
+def _reconcile_fcst_proportions_native(
+    y_hat_samples: np.ndarray,
+    idxs_top: np.ndarray,
+    flat: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> np.ndarray:
+    """Native batched forecast-proportions traversal.
+
+    Runs the `_reconcile_fcst_proportions` tree traversal for every
+    (sample, horizon) pair of `y_hat_samples` (`(n_samples, n_nodes, h)`) in
+    one C++ call, OpenMP-parallel across the independent pairs. The kernel
+    reproduces the reference's arithmetic exactly (NumPy's pairwise summation
+    for each parent's child sum, then the scalar multiply/divide chain), so
+    the output is bit-identical to running the pure-Python reference per
+    column.
+
+    The kernel computes in float64 only, so non-float64 input falls back to
+    the pure-Python reference, preserving the input dtype end-to-end.
+    """
+    parent_idx, child_indptr, child_idx = flat
+    if y_hat_samples.dtype != np.float64:
+        # The kernel accepts float64 only -- pybind11's `forcecast` would
+        # silently upcast e.g. float32 `y_hat` from direct TopDown/MiddleOut
+        # callers, changing both the arithmetic and the output dtype.
+        # `core.reconcile` coerces base forecasts to float64 upstream, so the
+        # main reconcile() path always takes the kernel; any other dtype runs
+        # the pure-Python reference below, which reproduces the pre-native
+        # behavior exactly in the input's native dtype. Presenting the flat
+        # parent list as a single level is equivalent to the reference's
+        # level-by-level traversal: parents are stored in traversal order, so
+        # every parent's reconciled value is written before it is read.
+        nodes_flat = {
+            "flat": {
+                int(p): child_idx[child_indptr[i] : child_indptr[i + 1]]
+                for i, p in enumerate(parent_idx)
+            }
+        }
+        tags_flat = {"flat": None, "leaves": None}
+        out = np.empty_like(y_hat_samples)
+        for s, y_hat_sample in enumerate(y_hat_samples):
+            out[s] = np.hstack(
+                [
+                    _reconcile_fcst_proportions(
+                        S=None,
+                        y_hat=y_hat_sample[:, [c]],
+                        tags=tags_flat,
+                        nodes=nodes_flat,
+                        idxs_top=idxs_top,
+                    )
+                    for c in range(y_hat_sample.shape[1])
+                ]
+            )
+        return out
+    return _lib_recon._forecast_proportions_traversal(
+        y_hat_samples,
+        parent_idx,
+        child_indptr,
+        child_idx,
+        np.ascontiguousarray(idxs_top, dtype=np.int64),
+    )
+
+
 def _reconcile_fcst_proportions(
     S: np.ndarray,
     y_hat: np.ndarray,
@@ -399,6 +487,13 @@ def _reconcile_fcst_proportions(
     nodes: dict[str, dict[int, np.ndarray]],
     idxs_top: np.ndarray,
 ):
+    """Pure-Python reference for the forecast-proportions traversal.
+
+    The runtime path is `_reconcile_fcst_proportions_native`; this
+    implementation is kept as the behavioral reference the regression tests
+    assert bit-identical equality against, and as the runtime fallback for
+    non-float64 input (the native kernel is float64-only).
+    """
     reconciled = np.zeros_like(y_hat)
     level_names = list(tags.keys())
     for idx_top in idxs_top:
@@ -431,12 +526,15 @@ def _reconcile_fcst_proportions_bootstrap(
     nodes: dict[str, dict[int, np.ndarray]] | None = None,
     idxs_top: np.ndarray | None = None,
     A: sparse.csr_matrix | None = None,
+    flat: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
 ):
     """Generate prediction intervals for forecast_proportions using bootstrap.
 
     This function generates bootstrap samples by adding resampled residuals to
     the base forecasts, then reconciles each sample using forecast proportions.
-    Supports both dense and sparse summing matrices.
+    Supports both dense and sparse summing matrices. For dense `S`, all
+    samples are reconciled by a single call into the native batched traversal
+    kernel instead of re-running the Python traversal per sample and column.
 
     Args:
         S: Summing matrix of size (`base`, `bottom`). Can be dense or sparse.
@@ -450,6 +548,7 @@ def _reconcile_fcst_proportions_bootstrap(
         nodes: Child nodes structure from _get_child_nodes (required for dense S).
         idxs_top: Indices of top-level nodes (required for dense S).
         A: Adjacency matrix (required for sparse S).
+        flat: Optional precomputed `_flatten_child_nodes(nodes)` arrays.
 
     Returns:
         quantiles: Array of shape (`base`, `horizon`, `num_quantiles`).
@@ -469,38 +568,40 @@ def _reconcile_fcst_proportions_bootstrap(
 
     # Generate bootstrap samples
     samples_idx = rng.choice(sample_idx, size=num_samples)
-    bootstrap_samples = []
 
-    for idx in samples_idx:
-        # Add residual block to forecasts
-        y_hat_sample = y_hat + residuals[:, idx : (idx + h)]
-
-        if is_sparse:
+    if is_sparse:
+        bootstrap_samples = []
+        for idx in samples_idx:
+            # Add residual block to forecasts
+            y_hat_sample = y_hat + residuals[:, idx : (idx + h)]
             # Reconcile the bootstrap sample using sparse forecast proportions
-            reconciled_sample = _reconcile_fcst_proportions_sparse(
-                S=S,
-                y_hat=y_hat_sample,
-                A=A,
-                tags=tags,
+            bootstrap_samples.append(
+                _reconcile_fcst_proportions_sparse(
+                    S=S,
+                    y_hat=y_hat_sample,
+                    A=A,
+                    tags=tags,
+                )
             )
-        else:
-            # Reconcile the bootstrap sample using dense forecast proportions
-            reconciled_sample = np.hstack(
-                [
-                    _reconcile_fcst_proportions(
-                        S=S,
-                        y_hat=y_hat_sample_col[:, None],
-                        tags=tags,
-                        nodes=nodes, # type: ignore[arg-type]
-                        idxs_top=idxs_top,
-                    )
-                    for y_hat_sample_col in y_hat_sample.T
-                ]
-            )
-        bootstrap_samples.append(reconciled_sample)
-
-    # Stack samples: [num_samples, n_series, horizon]
-    samples = np.stack(bootstrap_samples)
+        # Stack samples: [num_samples, n_series, horizon]
+        samples = np.stack(bootstrap_samples)
+    else:
+        if flat is None:
+            flat = _flatten_child_nodes(nodes)  # type: ignore[arg-type]
+        # Materialize every bootstrap sample's base forecasts at once:
+        # samples[s] == y_hat + residuals[:, idx_s : idx_s + h], elementwise
+        # identical to the per-sample construction above.
+        block_cols = samples_idx[:, None] + np.arange(h)[None, :]
+        y_hat_samples = y_hat[None, :, :] + residuals.T[block_cols].transpose(
+            0, 2, 1
+        )
+        # Reconcile all samples and horizon columns in one native call:
+        # [num_samples, n_series, horizon].
+        samples = _reconcile_fcst_proportions_native(
+            y_hat_samples,
+            idxs_top=idxs_top,  # type: ignore[arg-type]
+            flat=flat,
+        )
     # Transpose to [n_series, horizon, num_samples]
     samples = samples.transpose((1, 2, 0))
 
@@ -742,17 +843,14 @@ class TopDown(HReconciler):
                 idxs_top = np.array([np.argmax(S_sum)])
             levels_ = dict(sorted(tags.items(), key=lambda x: len(x[1])))
             nodes = _get_child_nodes(S=S, tags=levels_)
-            reconciled = [
-                _reconcile_fcst_proportions(
-                    S=S,
-                    y_hat=y_hat_[:, None],
-                    tags=levels_,
-                    nodes=nodes,
-                    idxs_top=idxs_top,
-                )
-                for y_hat_ in y_hat.T
-            ]
-            reconciled = np.hstack(reconciled)
+            flat = _flatten_child_nodes(nodes)
+            # Reconcile every horizon column in a single native traversal
+            # call (bit-identical to the per-column pure-Python reference).
+            reconciled = _reconcile_fcst_proportions_native(
+                y_hat[None, :, :],
+                idxs_top=idxs_top,
+                flat=flat,
+            )[0].astype(y_hat.dtype, copy=False)
             res = {"mean": reconciled}
 
             # Compute prediction intervals using bootstrap if requested
@@ -782,6 +880,7 @@ class TopDown(HReconciler):
                     level=level,
                     nodes=nodes,
                     idxs_top=idxs_top,
+                    flat=flat,
                 )
             return res
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 import glob
 import platform
 import subprocess
+from pathlib import Path
 
 import setuptools
 from pybind11.setup_helpers import ParallelCompile, Pybind11Extension, naive_recompile
+from setuptools.command.build_ext import build_ext
 
 extra_compile_args = []
 extra_link_args = []
@@ -27,6 +29,51 @@ elif platform.system() == "Darwin":
 elif platform.system() == "Windows":
     extra_compile_args += ["/openmp", "/O2", "/fp:fast", "/DNDEBUG"]
 
+# Sources that must keep strict IEEE floating-point semantics.
+# src/forecast_proportions.cpp ports NumPy's pairwise summation and must stay
+# bit-identical to the pure-Python reference traversal, including NaN/inf
+# propagation: under -ffast-math (finite-math-only) the kernel's
+# `std::abs(child_sum) < 1e-8` check is allowed to assume no NaNs, so a NaN
+# child sum silently takes the equal-split branch and produces finite output
+# where the reference propagates NaN. The in-file FP pragmas cannot fully undo
+# a driver-level -ffast-math on every toolchain, so these files are excluded
+# from fast-math here; the pragmas remain as defense-in-depth only.
+STRICT_FP_SOURCES = {"forecast_proportions.cpp"}
+
+
+class strict_fp_build_ext(build_ext):
+    """build_ext that compiles ``STRICT_FP_SOURCES`` without fast-math.
+
+    setuptools has no per-source flag support, so this hooks the per-file
+    compile step instead: on unix-like compilers it wraps ``_compile`` and
+    appends ``-fno-fast-math`` (the later flag overrides the earlier
+    ``-ffast-math`` on both gcc and clang); on MSVC, whose ``compile`` issues
+    one ``spawn`` per source, it wraps ``spawn`` and appends ``/fp:precise``
+    (the later flag overrides the earlier ``/fp:fast``).
+    """
+
+    def build_extensions(self):
+        if self.compiler.compiler_type == "msvc":
+            original_spawn = self.compiler.spawn
+
+            def spawn(cmd, *args, **kwargs):
+                if any(Path(str(part)).name in STRICT_FP_SOURCES for part in cmd):
+                    cmd = [*cmd, "/fp:precise"]
+                return original_spawn(cmd, *args, **kwargs)
+
+            self.compiler.spawn = spawn
+        else:
+            original_compile = self.compiler._compile
+
+            def _compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
+                if Path(src).name in STRICT_FP_SOURCES:
+                    extra_postargs = [*extra_postargs, "-fno-fast-math"]
+                return original_compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+            self.compiler._compile = _compile
+        super().build_extensions()
+
+
 ext_modules = [
     Pybind11Extension(
         name="hierarchicalforecast._lib",
@@ -42,4 +89,4 @@ ParallelCompile(
     "CMAKE_BUILD_PARALLEL_LEVEL", needs_recompile=naive_recompile
 ).install()
 
-setuptools.setup(ext_modules=ext_modules)
+setuptools.setup(ext_modules=ext_modules, cmdclass={"build_ext": strict_fp_build_ext})

--- a/src/forecast_proportions.cpp
+++ b/src/forecast_proportions.cpp
@@ -1,0 +1,254 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+// ---------- Floating-point strictness ----------
+// The traversal below must stay bit-identical to the sequential NumPy
+// reference implementation (`_reconcile_fcst_proportions` in
+// hierarchicalforecast/methods.py). The rest of the extension is compiled
+// with -ffast-math (/fp:fast on MSVC), which licenses the compiler to
+// rewrite `x * fp / s` into `x * fp * (1.0 / s)` (reciprocal hoisting of
+// the loop-invariant divisor), to re-associate/contract expressions, to
+// reorder the pairwise-summation accumulators, and -- via
+// finite-math-only -- to assume no NaN/inf, letting a NaN child sum slip
+// past the `|sum| < 1e-8` guard into the equal-split branch instead of
+// propagating NaN. This file is therefore excluded from fast-math at the
+// build level (see STRICT_FP_SOURCES in setup.py: -fno-fast-math on
+// gcc/clang, /fp:precise on MSVC); that per-source flag is the primary
+// guarantee. The pragmas below are secondary, defense-in-depth only (they
+// cannot fully undo a driver-level -ffast-math on every toolchain -- in
+// particular they do not restore NaN semantics under clang's
+// finite-math-only). The kernel is memory-bound scalar code, so fast-math
+// buys nothing here anyway.
+#if defined(_MSC_VER)
+#pragma float_control(precise, on, push)
+#elif defined(__GNUC__) && !defined(__clang__)
+#pragma GCC optimize("no-fast-math")
+#endif
+
+// Clang scopes its FP pragmas to compound statements; used inside functions.
+#if defined(__clang__) && __clang_major__ >= 14
+#define HF_STRICT_FP _Pragma("clang fp reassociate(off) reciprocal(off) contract(off)")
+#elif defined(__clang__)
+#define HF_STRICT_FP _Pragma("clang fp reassociate(off) contract(off)")
+#else
+#define HF_STRICT_FP
+#endif
+
+namespace reconciliation {
+
+namespace py = pybind11;
+
+namespace {
+
+// Faithful port of NumPy's `DOUBLE_pairwise_sum` (numpy/_core/src/umath/
+// loops_utils.h.src): sequential below 8 elements, an 8-accumulator unrolled
+// block up to PW_BLOCKSIZE = 128, and a recursive split (rounded down to a
+// multiple of 8) above that. NumPy ships a single generic C source for this
+// reduction (no per-architecture SIMD dispatch variant; verified for
+// numpy >= 1.21 -- the unroll is designed so compilers can vectorize it
+// *without changing the summation order*), so reproducing the association
+// tree here yields sums bit-identical to `np.sum` over the same contiguous
+// child-ordered values on every platform. Note: numpy < 2.0 seeded the n < 8
+// base case with `0.` instead of `-0.0`; the difference is unobservable here
+// (it only shows for an all `-0.0` child set, whose sum takes the
+// `|sum| < 1e-8` equal-split branch either way). `val(i)` abstracts the
+// gather `y_hat[child_idx[i], col]`; association depends only on `n`, not on
+// memory layout.
+template <typename F>
+double numpy_pairwise_sum(const F &val, int64_t off, int64_t n) {
+  HF_STRICT_FP
+  if (n < 8) {
+    // Start with -0.0 to preserve -0.0 (matches NumPy: `-0 + -0 == -0`
+    // while `0 + -0 == 0`).
+    double res = -0.0;
+    for (int64_t i = 0; i < n; ++i) {
+      res += val(off + i);
+    }
+    return res;
+  } else if (n <= 128) {
+    double r[8];
+    for (int64_t j = 0; j < 8; ++j) {
+      r[j] = val(off + j);
+    }
+    int64_t i = 8;
+    for (; i < n - (n % 8); i += 8) {
+      for (int64_t j = 0; j < 8; ++j) {
+        r[j] += val(off + i + j);
+      }
+    }
+    double res =
+        ((r[0] + r[1]) + (r[2] + r[3])) + ((r[4] + r[5]) + (r[6] + r[7]));
+    for (; i < n; ++i) {
+      res += val(off + i);
+    }
+    return res;
+  } else {
+    int64_t n2 = n / 2;
+    n2 -= n2 % 8;
+    return numpy_pairwise_sum(val, off, n2) +
+           numpy_pairwise_sum(val, off + n2, n - n2);
+  }
+}
+
+} // namespace
+
+// ---------- _forecast_proportions_traversal ----------
+// Batched top-down "forecast proportions" tree traversal.
+//
+// Replaces the 4-level nested Python loop in `_reconcile_fcst_proportions`
+// (top nodes x levels x parents x children), which was re-executed once per
+// horizon column and, for bootstrap prediction intervals, once per bootstrap
+// sample (a 100-10,000x multiplier). This kernel performs the full traversal
+// for every (sample, horizon) pair in a single call.
+//
+// The child-node structure arrives flattened CSR-style (see
+// `_flatten_child_nodes` in methods.py): parents are listed in traversal
+// order (levels top-to-bottom, insertion order within each level), and
+// `child_idx[child_indptr[p]:child_indptr[p+1]]` are the children of
+// `parent_idx[p]`. Because every parent's reconciled value is written (as a
+// top node or as a child of the previous level) before it is read, a single
+// pass over this flat list is exactly equivalent to the reference's
+// level-by-level traversal.
+//
+// Bit-exactness: per-parent child sums use `numpy_pairwise_sum` above (the
+// same association tree as the reference's `y_hat[idx_childs].sum()`), and
+// the per-child update is the reference's scalar `y * fp / s` chain with
+// fast-math transforms disabled for this translation unit. OpenMP
+// parallelism only spans the fully independent (sample, horizon) pairs --
+// never inside a node's accumulation -- so results are deterministic and
+// bit-identical to a serial run for any thread count.
+//
+// samples:      (n_samples, n_nodes, h) float64, base forecasts per sample.
+// parent_idx:   (n_parents,) int64, node index of each parent.
+// child_indptr: (n_parents + 1,) int64, CSR offsets into child_idx.
+// child_idx:    (n_children_total,) int64, node index of each child.
+// top_idx:      (n_top,) int64, node indices seeded with their own forecast.
+// Returns:      (n_samples, n_nodes, h) float64 reconciled forecasts; nodes
+//               not reached by the traversal stay 0, as in the reference.
+py::array_t<double> forecast_proportions_traversal(
+    const py::array_t<double, py::array::c_style | py::array::forcecast>
+        &samples_arr,
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast>
+        &parent_idx_arr,
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast>
+        &child_indptr_arr,
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast>
+        &child_idx_arr,
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast>
+        &top_idx_arr) {
+  const auto sm = samples_arr.unchecked<3>();
+  const auto par = parent_idx_arr.unchecked<1>();
+  const auto iptr = child_indptr_arr.unchecked<1>();
+  const auto cidx = child_idx_arr.unchecked<1>();
+  const auto top = top_idx_arr.unchecked<1>();
+
+  const py::ssize_t n_samples = sm.shape(0);
+  const py::ssize_t n_nodes = sm.shape(1);
+  const py::ssize_t h = sm.shape(2);
+  const py::ssize_t n_parents = par.shape(0);
+  const py::ssize_t n_children_total = cidx.shape(0);
+  const py::ssize_t n_top = top.shape(0);
+
+  if (iptr.shape(0) != n_parents + 1) {
+    throw std::invalid_argument(
+        "child_indptr must have shape (n_parents + 1,)");
+  }
+  if (iptr(0) != 0 || iptr(n_parents) != n_children_total) {
+    throw std::invalid_argument(
+        "child_indptr must start at 0 and end at len(child_idx)");
+  }
+  for (py::ssize_t p = 0; p < n_parents; ++p) {
+    if (iptr(p) > iptr(p + 1)) {
+      throw std::invalid_argument("child_indptr must be non-decreasing");
+    }
+    if (par(p) < 0 || par(p) >= n_nodes) {
+      throw std::invalid_argument("parent_idx out of bounds");
+    }
+  }
+  for (py::ssize_t i = 0; i < n_children_total; ++i) {
+    if (cidx(i) < 0 || cidx(i) >= n_nodes) {
+      throw std::invalid_argument("child_idx out of bounds");
+    }
+  }
+  for (py::ssize_t k = 0; k < n_top; ++k) {
+    if (top(k) < 0 || top(k) >= n_nodes) {
+      throw std::invalid_argument("top_idx out of bounds");
+    }
+  }
+
+  py::array_t<double> out_arr({n_samples, n_nodes, h});
+  auto out = out_arr.mutable_unchecked<3>();
+  double *out_ptr = out_arr.mutable_data();
+
+  {
+    // Manual release rather than this module's usual
+    // `py::call_guard<py::gil_scoped_release>` (see reconciliation.cpp):
+    // the validation and output allocation above deliberately stay under
+    // the GIL; only this pure-compute region runs without it.
+    py::gil_scoped_release release;
+
+    const py::ssize_t total = n_samples * n_nodes * h;
+    std::fill(out_ptr, out_ptr + total, 0.0);
+
+    // Each (sample, column) pair is a fully independent serial traversal
+    // writing to disjoint output entries: parallelizing across them is
+    // deterministic and bit-identical to a serial run. The pair loop is
+    // flattened by hand because MSVC's OpenMP 2.0 lacks `collapse(2)`.
+    const py::ssize_t n_pairs = n_samples * h;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (py::ssize_t sc = 0; sc < n_pairs; ++sc) {
+      HF_STRICT_FP
+      const py::ssize_t s = sc / h;
+      const py::ssize_t c = sc % h;
+      for (py::ssize_t k = 0; k < n_top; ++k) {
+        const int64_t t = top(k);
+        out(s, t, c) = sm(s, t, c);
+      }
+      for (py::ssize_t p = 0; p < n_parents; ++p) {
+        const double fcst_parent = out(s, par(p), c);
+        const int64_t i0 = iptr(p);
+        const int64_t i1 = iptr(p + 1);
+        const double child_sum = numpy_pairwise_sum(
+            [&](int64_t i) { return sm(s, cidx(i), c); }, i0, i1 - i0);
+        if (std::abs(child_sum) < 1e-8) {
+          const double n_children = static_cast<double>(i1 - i0);
+          for (int64_t i = i0; i < i1; ++i) {
+            out(s, cidx(i), c) = fcst_parent / n_children;
+          }
+        } else {
+          for (int64_t i = i0; i < i1; ++i) {
+            const int64_t ch = cidx(i);
+            out(s, ch, c) = sm(s, ch, c) * fcst_parent / child_sum;
+          }
+        }
+      }
+    }
+  }
+  return out_arr;
+}
+
+// ---------- Module init ----------
+void init_forecast_proportions(py::module_ &recon) {
+  recon.def("_forecast_proportions_traversal", &forecast_proportions_traversal,
+            py::arg("samples"), py::arg("parent_idx"), py::arg("child_indptr"),
+            py::arg("child_idx"), py::arg("top_idx"),
+            "Batched top-down forecast-proportions traversal over all "
+            "(sample, horizon) pairs.");
+}
+
+} // namespace reconciliation
+
+#if defined(_MSC_VER)
+#pragma float_control(pop)
+#endif

--- a/src/reconciliation.cpp
+++ b/src/reconciliation.cpp
@@ -362,8 +362,13 @@ VectorXd lasso(const Eigen::Ref<const MatrixXd> &X,
 }
 
 // ---------- Module init ----------
+// Defined in forecast_proportions.cpp (kept in its own translation unit so
+// its strict floating-point pragmas don't affect the kernels in this file).
+void init_forecast_proportions(py::module_ &recon);
+
 void init(py::module_ &m) {
   py::module_ recon = m.def_submodule("reconciliation");
+  init_forecast_proportions(recon);
   recon.def("get_num_threads", &get_num_threads,
             "Return the maximum number of OpenMP threads.");
   recon.def("set_num_threads", &set_num_threads, py::arg("n"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,75 @@ def _make_random_strict_hierarchy(rng, level_sizes, shuffle_tags=True):
         row_offset += size
     return S, tags
 
+def _topdown_idxs_top(S):
+    """Replicate `TopDown.fit_predict`'s top-node selection for direct calls
+    into the forecast-proportions helpers from tests and benchmarks."""
+    S_sum = np.sum(S, axis=1)
+    if S.shape[1] > 1:
+        S_max_idxs = np.argsort(S_sum)[::-1]
+        return S_max_idxs[np.cumsum(S_sum[S_max_idxs]) <= S.shape[1]]
+    return np.array([np.argmax(S_sum)])
+
+
+def _reconcile_fcst_proportions_columns_python(S, y_hat, tags, nodes, idxs_top):
+    """Pre-native runtime path: run the pure-Python
+    `_reconcile_fcst_proportions` traversal once per horizon column.
+
+    Kept as the behavioral reference the native batched kernel is asserted
+    bit-identical against, and as the "before" side of the benchmarks. Shared
+    by `tests/test_methods.py` and `tests/test_benchmarks.py`.
+    """
+    from hierarchicalforecast.methods import _reconcile_fcst_proportions
+
+    return np.hstack(
+        [
+            _reconcile_fcst_proportions(
+                S=S,
+                y_hat=y_hat_[:, None],
+                tags=tags,
+                nodes=nodes,
+                idxs_top=idxs_top,
+            )
+            for y_hat_ in y_hat.T
+        ]
+    )
+
+
+def _reconcile_fcst_proportions_bootstrap_python(
+    S, y_hat, tags, y_insample, y_hat_insample, num_samples, seed, level, nodes, idxs_top
+):
+    """Pre-native dense bootstrap path: resample residual blocks and run the
+    pure-Python traversal per sample and per horizon column.
+
+    Mirrors `_reconcile_fcst_proportions_bootstrap`'s dense branch before the
+    native batched kernel replaced the inner loops; the rng usage is identical
+    so, for the same seed, the native path must produce bit-identical
+    quantiles. Shared by `tests/test_methods.py` and `tests/test_benchmarks.py`.
+    """
+    residuals = y_insample - y_hat_insample
+    h = y_hat.shape[1]
+    residuals = residuals[:, np.isnan(residuals).sum(axis=0) == 0]
+    sample_idx = np.arange(residuals.shape[1] - h)
+    rng = np.random.default_rng(seed)
+    samples_idx = rng.choice(sample_idx, size=num_samples)
+    bootstrap_samples = []
+    for idx in samples_idx:
+        y_hat_sample = y_hat + residuals[:, idx : (idx + h)]
+        bootstrap_samples.append(
+            _reconcile_fcst_proportions_columns_python(
+                S=S, y_hat=y_hat_sample, tags=tags, nodes=nodes, idxs_top=idxs_top
+            )
+        )
+    samples = np.stack(bootstrap_samples)
+    samples = samples.transpose((1, 2, 0))
+    quantiles = np.concatenate(
+        [[(100 - lv) / 200, ((100 - lv) / 200) + lv / 100] for lv in level]
+    )
+    quantiles = np.sort(quantiles)
+    sample_quantiles = np.quantile(samples, quantiles, axis=2)
+    return sample_quantiles.transpose((1, 2, 0))
+
+
 @pytest.fixture(scope="module")
 def tourism_df():
     df = pd.read_csv('https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/tourism.csv')

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -2,7 +2,12 @@ import numpy as np
 import pytest
 from scipy import sparse
 
-from hierarchicalforecast.methods import _get_child_nodes
+from hierarchicalforecast.methods import (
+    _flatten_child_nodes,
+    _get_child_nodes,
+    _reconcile_fcst_proportions_bootstrap,
+    _reconcile_fcst_proportions_native,
+)
 from hierarchicalforecast.probabilistic_methods import Bootstrap
 from hierarchicalforecast.utils import (
     _lasso,
@@ -11,7 +16,12 @@ from hierarchicalforecast.utils import (
     _shrunk_covariance_schaferstrimmer_with_nans,
 )
 
-from .conftest import _make_random_strict_hierarchy
+from .conftest import (
+    _make_random_strict_hierarchy,
+    _reconcile_fcst_proportions_bootstrap_python,
+    _reconcile_fcst_proportions_columns_python,
+    _topdown_idxs_top,
+)
 
 pytestmark = pytest.mark.benchmark
 
@@ -109,3 +119,123 @@ def test_bench_get_child_nodes(benchmark, child_nodes_bench_data, as_sparse):
     if as_sparse:
         S = sparse.csr_matrix(S)
     benchmark(_get_child_nodes, S=S, tags=tags)
+
+
+@pytest.fixture
+def fcst_proportions_bench_data():
+    """1000-bottom-series/3-level hierarchy, h=12, for benchmarking the
+    forecast-proportions traversal (old per-column Python loop vs the native
+    batched kernel)."""
+    rng = np.random.default_rng(789)
+    S, tags = _make_random_strict_hierarchy(
+        rng, level_sizes=[1, 20, 1000], shuffle_tags=False
+    )
+    n_hiers = S.shape[0]
+    h = 12
+    insample_size = 60
+
+    y_hat = 100.0 + 10.0 * rng.standard_normal((n_hiers, h))
+    y_insample = 100.0 + 10.0 * rng.standard_normal((n_hiers, insample_size))
+    y_hat_insample = y_insample + rng.standard_normal((n_hiers, insample_size))
+
+    levels_ = dict(sorted(tags.items(), key=lambda x: len(x[1])))
+    nodes = _get_child_nodes(S=S, tags=levels_)
+    flat = _flatten_child_nodes(nodes)
+    idxs_top = _topdown_idxs_top(S)
+    return {
+        "S": S,
+        "tags": levels_,
+        "nodes": nodes,
+        "flat": flat,
+        "idxs_top": idxs_top,
+        "y_hat": y_hat,
+        "y_insample": y_insample,
+        "y_hat_insample": y_hat_insample,
+    }
+
+
+@pytest.mark.parametrize("impl", ["python", "native"])
+def test_bench_fcst_proportions_mean(benchmark, fcst_proportions_bench_data, impl):
+    """TopDown `forecast_proportions` mean path: traversal over all 12
+    horizon columns."""
+    d = fcst_proportions_bench_data
+    if impl == "python":
+        benchmark(
+            _reconcile_fcst_proportions_columns_python,
+            S=d["S"],
+            y_hat=d["y_hat"],
+            tags=d["tags"],
+            nodes=d["nodes"],
+            idxs_top=d["idxs_top"],
+        )
+    else:
+        benchmark(
+            _reconcile_fcst_proportions_native,
+            d["y_hat"][None, :, :],
+            idxs_top=d["idxs_top"],
+            flat=d["flat"],
+        )
+
+
+@pytest.mark.parametrize("impl", ["python", "native"])
+def test_bench_fcst_proportions_bootstrap_100(
+    benchmark, fcst_proportions_bench_data, impl
+):
+    """Bootstrap prediction intervals with 100 samples (the per-sample
+    multiplier is what made the Python loop explode)."""
+    d = fcst_proportions_bench_data
+    if impl == "python":
+        benchmark.pedantic(
+            _reconcile_fcst_proportions_bootstrap_python,
+            kwargs=dict(
+                S=d["S"],
+                y_hat=d["y_hat"],
+                tags=d["tags"],
+                y_insample=d["y_insample"],
+                y_hat_insample=d["y_hat_insample"],
+                num_samples=100,
+                seed=0,
+                level=[80, 95],
+                nodes=d["nodes"],
+                idxs_top=d["idxs_top"],
+            ),
+            rounds=3,
+            iterations=1,
+        )
+    else:
+        benchmark(
+            _reconcile_fcst_proportions_bootstrap,
+            S=d["S"],
+            y_hat=d["y_hat"],
+            tags=d["tags"],
+            y_insample=d["y_insample"],
+            y_hat_insample=d["y_hat_insample"],
+            num_samples=100,
+            seed=0,
+            level=[80, 95],
+            nodes=d["nodes"],
+            idxs_top=d["idxs_top"],
+            flat=d["flat"],
+        )
+
+
+def test_bench_fcst_proportions_bootstrap_1000_native(
+    benchmark, fcst_proportions_bench_data
+):
+    """Native-only: bootstrap with 1000 samples (12,000 traversals per call),
+    infeasible to benchmark with the old Python loop at this size."""
+    d = fcst_proportions_bench_data
+    benchmark(
+        _reconcile_fcst_proportions_bootstrap,
+        S=d["S"],
+        y_hat=d["y_hat"],
+        tags=d["tags"],
+        y_insample=d["y_insample"],
+        y_hat_insample=d["y_hat_insample"],
+        num_samples=1000,
+        seed=0,
+        level=[80, 95],
+        nodes=d["nodes"],
+        idxs_top=d["idxs_top"],
+        flat=d["flat"],
+    )

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from scipy import sparse
 
+import hierarchicalforecast.methods as hf_methods
 from hierarchicalforecast.methods import (
     ERM,
     BottomUp,
@@ -15,13 +16,22 @@ from hierarchicalforecast.methods import (
     OptimalCombination,
     TopDown,
     TopDownSparse,
+    _flatten_child_nodes,
     _get_child_nodes,
     _is_strictly_hierarchical,
+    _reconcile_fcst_proportions,
+    _reconcile_fcst_proportions_bootstrap,
+    _reconcile_fcst_proportions_native,
     is_strictly_hierarchical,
 )
 from hierarchicalforecast.utils import _construct_adjacency_matrix
 
-from .conftest import _make_random_strict_hierarchy
+from .conftest import (
+    _make_random_strict_hierarchy,
+    _reconcile_fcst_proportions_bootstrap_python,
+    _reconcile_fcst_proportions_columns_python,
+    _topdown_idxs_top,
+)
 
 
 @dataclass
@@ -1249,3 +1259,476 @@ class TestGetChildNodes:
         cls_top_down = TopDown(method="forecast_proportions")
         result = cls_top_down(S=data.S, y_hat=data.S @ data.y_hat_bottom, tags=data.tags)["mean"]
         np.testing.assert_allclose(result, data.S @ data.y_hat_bottom)
+
+
+def _native_via_python_reference(y_hat_samples, idxs_top, flat):
+    """Drop-in replacement for `_reconcile_fcst_proportions_native` that
+    routes every (sample, column) pair through the pure-Python
+    `_reconcile_fcst_proportions` reference.
+
+    The flat parent list is presented to the reference as a single-level
+    `nodes`/`tags` pair: a flat pass in traversal order is exactly the
+    reference's level-by-level traversal (every parent's value is written
+    before it is read), so this reconstructs the pre-native runtime path from
+    the same inputs the kernel sees. Used to monkeypatch the native call and
+    assert end-to-end bit-identical public API outputs.
+    """
+    parent_idx, child_indptr, child_idx = flat
+    nodes_stub = {
+        "parents": {
+            int(p): child_idx[child_indptr[i] : child_indptr[i + 1]].tolist()
+            for i, p in enumerate(parent_idx)
+        }
+    }
+    tags_stub = {"parents": None, "children": None}
+    out = np.empty_like(y_hat_samples)
+    for s in range(y_hat_samples.shape[0]):
+        out[s] = np.hstack(
+            [
+                _reconcile_fcst_proportions(
+                    S=None,
+                    y_hat=y_hat_samples[s][:, [c]],
+                    tags=tags_stub,
+                    nodes=nodes_stub,
+                    idxs_top=idxs_top,
+                )
+                for c in range(y_hat_samples.shape[2])
+            ]
+        )
+    return out
+
+
+class TestForecastProportionsNative:
+    """Regression tests for the native batched forecast-proportions traversal.
+
+    The pre-native runtime re-ran the 4-level Python traversal
+    (`_reconcile_fcst_proportions`) once per horizon column and, for bootstrap
+    prediction intervals, once per bootstrap sample. The native kernel
+    (`_forecast_proportions_traversal`) performs the traversal for all
+    (sample, horizon) pairs in one call but must stay bit-identical to the
+    pure-Python reference: it ports NumPy's pairwise summation for the child
+    sums and disables fast-math transforms for the scalar multiply/divide
+    chain, so every assertion here is exact equality, not allclose.
+    """
+
+    @staticmethod
+    def _setup(S, tags):
+        levels_ = dict(sorted(tags.items(), key=lambda x: len(x[1])))
+        nodes = _get_child_nodes(S=S, tags=levels_)
+        flat = _flatten_child_nodes(nodes)
+        idxs_top = _topdown_idxs_top(S)
+        return levels_, nodes, flat, idxs_top
+
+    def test_flatten_child_nodes_structure(self, hierarchical_data):
+        data = hierarchical_data
+        levels_, nodes, flat, _ = self._setup(data.S, data.tags)
+        parent_idx, child_indptr, child_idx = flat
+
+        expected_parents = []
+        expected_children = []
+        for nodes_level in nodes.values():
+            for idx_parent, idx_childs in nodes_level.items():
+                expected_parents.append(idx_parent)
+                expected_children.append(list(idx_childs))
+
+        assert parent_idx.dtype == np.int64
+        assert child_indptr.dtype == np.int64
+        assert child_idx.dtype == np.int64
+        assert list(parent_idx) == expected_parents
+        assert child_indptr[0] == 0
+        assert child_indptr[-1] == len(child_idx)
+        for p, childs in enumerate(expected_children):
+            got = child_idx[child_indptr[p] : child_indptr[p + 1]]
+            assert list(got) == childs
+
+    @pytest.mark.parametrize(
+        "level_sizes",
+        [
+            [1, 2, 4],
+            [1, 5, 9, 40],
+            [1, 3, 7, 100],
+            [1, 40],
+            [2, 6, 30],
+            [1, 200],
+        ],
+    )
+    def test_matches_reference_random_hierarchies(self, level_sizes):
+        """Fuzz the native traversal against the per-column Python reference.
+
+        Covers small fan-outs (sequential summation), fan-outs above NumPy's
+        8-element unroll, and a 200-child parent that exercises the recursive
+        pairwise-summation split above the 128-element block size.
+        """
+        seed = zlib.crc32(
+            repr(("fcst_proportions_native", tuple(level_sizes))).encode()
+        )
+        rng = np.random.default_rng(seed)
+        for _ in range(3):
+            S, tags = _make_random_strict_hierarchy(rng, level_sizes)
+            levels_, nodes, flat, idxs_top = self._setup(S, tags)
+            y_hat = rng.normal(100.0, 20.0, size=(S.shape[0], 5))
+
+            expected = _reconcile_fcst_proportions_columns_python(
+                S=S, y_hat=y_hat, tags=levels_, nodes=nodes, idxs_top=idxs_top
+            )
+            result = _reconcile_fcst_proportions_native(
+                y_hat[None, :, :], idxs_top=idxs_top, flat=flat
+            )[0]
+            np.testing.assert_array_equal(result, expected)
+
+    def test_matches_reference_zero_children_sum(self):
+        """Parents whose children sum to ~0 take the `fcst_parent / n` branch."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_zero_sum"))
+        S, tags = _make_random_strict_hierarchy(rng, [1, 4, 12])
+        levels_, nodes, flat, idxs_top = self._setup(S, tags)
+        y_hat = rng.normal(100.0, 20.0, size=(S.shape[0], 4))
+
+        # Zero out the children of one parent per level (including one column
+        # left at exactly 0.0 and one at values summing below the 1e-8
+        # threshold).
+        for nodes_level in nodes.values():
+            idx_childs = next(iter(nodes_level.values()))
+            y_hat[list(idx_childs), :] = 0.0
+            y_hat[list(idx_childs), 1] = 1e-10 / len(idx_childs)
+
+        expected = _reconcile_fcst_proportions_columns_python(
+            S=S, y_hat=y_hat, tags=levels_, nodes=nodes, idxs_top=idxs_top
+        )
+        result = _reconcile_fcst_proportions_native(
+            y_hat[None, :, :], idxs_top=idxs_top, flat=flat
+        )[0]
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "bad_children",
+        [
+            pytest.param([1.0, np.nan, 2.0], id="nan_child"),
+            pytest.param([np.inf, -np.inf, 2.0], id="inf_minus_inf_children"),
+        ],
+    )
+    def test_non_finite_child_sums_propagate_like_reference(self, bad_children):
+        """NaN child sums must propagate NaN, bit-identical to the reference.
+
+        Guards the fast-math regression: under -ffast-math (finite-math-only)
+        the kernel's `|child_sum| < 1e-8` guard is allowed to assume no NaNs,
+        so a NaN child sum silently took the equal-split branch and produced
+        finite output (e.g. [10, 3.33, 3.33, 3.33]) where the reference
+        propagates NaN ([10, nan, nan, nan]). The kernel's translation unit
+        is now compiled without fast-math (STRICT_FP_SOURCES in setup.py);
+        this test fails loudly if that per-source flag ever regresses.
+        Covers both a literal NaN child and an inf + -inf pair whose sum is
+        NaN.
+        """
+        # Star hierarchy: one total on top of three bottom series.
+        S = np.array(
+            [
+                [1.0, 1.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        tags = {"level0": np.array([0]), "level1": np.array([1, 2, 3])}
+        levels_, nodes, flat, idxs_top = self._setup(S, tags)
+        y_hat = np.array([10.0, *bad_children])[:, None]
+
+        with np.errstate(invalid="ignore"):
+            expected = _reconcile_fcst_proportions_columns_python(
+                S=S, y_hat=y_hat, tags=levels_, nodes=nodes, idxs_top=idxs_top
+            )
+        result = _reconcile_fcst_proportions_native(
+            y_hat[None, :, :], idxs_top=idxs_top, flat=flat
+        )[0]
+
+        # The reference propagates NaN into every child of the poisoned
+        # parent; assert_array_equal treats positionally-matching NaNs as
+        # equal, so this is still an exact (bit-identical) comparison.
+        assert np.isnan(expected[1:]).all()
+        np.testing.assert_array_equal(result, expected)
+
+    def test_non_float64_input_falls_back_to_reference(self):
+        """float32 input bypasses the kernel and preserves dtype end-to-end.
+
+        The kernel computes in float64 only; pybind11's `forcecast` would
+        silently upcast float32 `y_hat` from direct TopDown/MiddleOut callers,
+        changing both the arithmetic and the output dtype.
+        `_reconcile_fcst_proportions_native` instead falls back to the
+        pure-Python reference, reproducing the pre-native behavior exactly in
+        the input's native dtype (`core.reconcile` coerces to float64
+        upstream, so the main reconcile() path is unaffected).
+        """
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_float32"))
+        S, tags = _make_random_strict_hierarchy(rng, [1, 4, 12])
+        levels_, nodes, flat, idxs_top = self._setup(S, tags)
+        y_hat = rng.normal(100.0, 20.0, size=(S.shape[0], 5)).astype(np.float32)
+
+        # Old behavior: the pure-Python traversal per column, float32 in/out.
+        expected = _reconcile_fcst_proportions_columns_python(
+            S=S, y_hat=y_hat, tags=levels_, nodes=nodes, idxs_top=idxs_top
+        )
+        assert expected.dtype == np.float32
+
+        result = _reconcile_fcst_proportions_native(
+            y_hat[None, :, :], idxs_top=idxs_top, flat=flat
+        )[0]
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, expected)
+
+        # Same through the public mean path.
+        result_api = TopDown(method="forecast_proportions")(
+            S=S, y_hat=y_hat, tags=tags
+        )["mean"]
+        assert result_api.dtype == np.float32
+        np.testing.assert_array_equal(result_api, expected)
+
+    def test_non_float64_bootstrap_falls_back_to_reference(self):
+        """float32 bootstrap intervals match the pre-native Python loop
+        exactly and preserve the input dtype."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_float32_boot"))
+        S, tags = _make_random_strict_hierarchy(rng, [1, 3, 9])
+        levels_, nodes, flat, idxs_top = self._setup(S, tags)
+        n = S.shape[0]
+        h, insample_size = 5, 30
+        y_hat = rng.normal(100.0, 20.0, size=(n, h)).astype(np.float32)
+        y_insample = rng.normal(100.0, 20.0, size=(n, insample_size)).astype(
+            np.float32
+        )
+        y_hat_insample = y_insample + rng.normal(
+            0.0, 5.0, size=(n, insample_size)
+        ).astype(np.float32)
+
+        expected = _reconcile_fcst_proportions_bootstrap_python(
+            S=S,
+            y_hat=y_hat,
+            tags=levels_,
+            y_insample=y_insample,
+            y_hat_insample=y_hat_insample,
+            num_samples=20,
+            seed=42,
+            level=[80, 95],
+            nodes=nodes,
+            idxs_top=idxs_top,
+        )
+        result = _reconcile_fcst_proportions_bootstrap(
+            S=S,
+            y_hat=y_hat,
+            tags=levels_,
+            y_insample=y_insample,
+            y_hat_insample=y_hat_insample,
+            num_samples=20,
+            seed=42,
+            level=[80, 95],
+            nodes=nodes,
+            idxs_top=idxs_top,
+            flat=flat,
+        )
+        assert result.dtype == expected.dtype
+        np.testing.assert_array_equal(result, expected)
+
+    def test_partial_top_nodes_leave_other_subtrees_untouched(self):
+        """Nodes outside the seeded top nodes' traversal stay identical to the
+        reference (which propagates the unseeded root's 0.0)."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_partial_top"))
+        S, tags = _make_random_strict_hierarchy(rng, [2, 5, 20])
+        levels_, nodes, flat, _ = self._setup(S, tags)
+        y_hat = rng.normal(100.0, 20.0, size=(S.shape[0], 3))
+
+        # Seed only one of the two roots.
+        idxs_top = np.asarray([tags["level0"][0]], dtype=np.int64)
+        expected = _reconcile_fcst_proportions_columns_python(
+            S=S, y_hat=y_hat, tags=levels_, nodes=nodes, idxs_top=idxs_top
+        )
+        result = _reconcile_fcst_proportions_native(
+            y_hat[None, :, :], idxs_top=idxs_top, flat=flat
+        )[0]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_batched_samples_match_per_sample_calls(self):
+        """One batched call over S samples equals S single-sample calls."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_batched"))
+        S, tags = _make_random_strict_hierarchy(rng, [1, 5, 9, 40])
+        _, _, flat, idxs_top = self._setup(S, tags)
+        y_hat_samples = rng.normal(100.0, 20.0, size=(7, S.shape[0], 6))
+
+        batched = _reconcile_fcst_proportions_native(
+            y_hat_samples, idxs_top=idxs_top, flat=flat
+        )
+        for s in range(y_hat_samples.shape[0]):
+            single = _reconcile_fcst_proportions_native(
+                y_hat_samples[s][None, :, :], idxs_top=idxs_top, flat=flat
+            )[0]
+            np.testing.assert_array_equal(batched[s], single)
+
+    def test_topdown_end_to_end_matches_python_reference(
+        self, hierarchical_data, monkeypatch
+    ):
+        """Public API: TopDown `forecast_proportions` output is bit-identical
+        with the native kernel and with the pure-Python reference."""
+        data = hierarchical_data
+        y_hat = data.S @ data.y_hat_bottom
+
+        result_native = TopDown(method="forecast_proportions")(
+            S=data.S, y_hat=y_hat, tags=data.tags
+        )["mean"]
+        monkeypatch.setattr(
+            hf_methods,
+            "_reconcile_fcst_proportions_native",
+            _native_via_python_reference,
+        )
+        result_python = TopDown(method="forecast_proportions")(
+            S=data.S, y_hat=y_hat, tags=data.tags
+        )["mean"]
+
+        np.testing.assert_array_equal(result_native, result_python)
+
+    def test_middle_out_end_to_end_matches_python_reference(
+        self, hierarchical_data, monkeypatch
+    ):
+        """Public API: MiddleOut with `forecast_proportions` (which re-enters
+        TopDown once per cut node) is bit-identical to the Python reference."""
+        data = hierarchical_data
+        y_hat = data.S @ data.y_hat_bottom
+
+        result_native = MiddleOut(
+            middle_level="level2", top_down_method="forecast_proportions"
+        )(S=data.S, y_hat=y_hat, tags=data.tags)["mean"]
+        monkeypatch.setattr(
+            hf_methods,
+            "_reconcile_fcst_proportions_native",
+            _native_via_python_reference,
+        )
+        result_python = MiddleOut(
+            middle_level="level2", top_down_method="forecast_proportions"
+        )(S=data.S, y_hat=y_hat, tags=data.tags)["mean"]
+
+        np.testing.assert_array_equal(result_native, result_python)
+
+    def test_middle_out_random_hierarchy_matches_python_reference(
+        self, monkeypatch
+    ):
+        """MiddleOut equivalence on a larger random strict hierarchy."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_middle_out"))
+        S, tags = _make_random_strict_hierarchy(
+            rng, [1, 4, 10, 60], shuffle_tags=False
+        )
+        y_hat = rng.normal(100.0, 20.0, size=(S.shape[0], 4))
+
+        result_native = MiddleOut(
+            middle_level="level1", top_down_method="forecast_proportions"
+        )(S=S, y_hat=y_hat, tags=tags)["mean"]
+        monkeypatch.setattr(
+            hf_methods,
+            "_reconcile_fcst_proportions_native",
+            _native_via_python_reference,
+        )
+        result_python = MiddleOut(
+            middle_level="level1", top_down_method="forecast_proportions"
+        )(S=S, y_hat=y_hat, tags=tags)["mean"]
+
+        np.testing.assert_array_equal(result_native, result_python)
+
+    def test_bootstrap_matches_python_reference_seeded(self):
+        """Dense bootstrap quantiles are bit-identical to the pre-native
+        per-sample/per-column Python loop for the same seed."""
+        rng = np.random.default_rng(zlib.crc32(b"fcst_proportions_bootstrap"))
+        for level_sizes in ([1, 3, 9], [1, 5, 9, 40]):
+            S, tags = _make_random_strict_hierarchy(rng, level_sizes)
+            levels_, nodes, flat, idxs_top = self._setup(S, tags)
+            n = S.shape[0]
+            h, insample_size = 6, 40
+            y_hat = rng.normal(100.0, 20.0, size=(n, h))
+            y_insample = rng.normal(100.0, 20.0, size=(n, insample_size))
+            y_hat_insample = y_insample + rng.normal(0.0, 5.0, size=(n, insample_size))
+
+            expected = _reconcile_fcst_proportions_bootstrap_python(
+                S=S,
+                y_hat=y_hat,
+                tags=levels_,
+                y_insample=y_insample,
+                y_hat_insample=y_hat_insample,
+                num_samples=50,
+                seed=42,
+                level=[80, 95],
+                nodes=nodes,
+                idxs_top=idxs_top,
+            )
+            result = _reconcile_fcst_proportions_bootstrap(
+                S=S,
+                y_hat=y_hat,
+                tags=levels_,
+                y_insample=y_insample,
+                y_hat_insample=y_hat_insample,
+                num_samples=50,
+                seed=42,
+                level=[80, 95],
+                nodes=nodes,
+                idxs_top=idxs_top,
+                flat=flat,
+            )
+            np.testing.assert_array_equal(result, expected)
+
+    def test_topdown_bootstrap_end_to_end_matches_python_reference(
+        self, hierarchical_data, monkeypatch
+    ):
+        """Public API with prediction intervals: mean and quantiles are
+        bit-identical between the native path and the Python reference."""
+        data = hierarchical_data
+        y_hat = data.S @ data.y_hat_bottom
+        y_insample = data.S @ data.y_bottom
+        y_hat_insample = data.S @ data.y_hat_bottom_insample
+        kwargs = dict(
+            S=data.S,
+            y_hat=y_hat,
+            tags=data.tags,
+            y_insample=y_insample,
+            y_hat_insample=y_hat_insample,
+            level=[80, 90],
+            intervals_method="bootstrap",
+            num_samples=100,
+            seed=42,
+        )
+
+        result_native = TopDown(method="forecast_proportions")(**kwargs)
+        monkeypatch.setattr(
+            hf_methods,
+            "_reconcile_fcst_proportions_native",
+            _native_via_python_reference,
+        )
+        result_python = TopDown(method="forecast_proportions")(**kwargs)
+
+        np.testing.assert_array_equal(result_native["mean"], result_python["mean"])
+        np.testing.assert_array_equal(
+            result_native["quantiles"], result_python["quantiles"]
+        )
+
+    def test_kernel_validates_inputs(self):
+        """Malformed flat arrays raise instead of reading out of bounds."""
+        from hierarchicalforecast._lib import reconciliation as _lib_recon
+
+        y = np.zeros((1, 3, 2))
+        i64 = lambda *xs: np.asarray(xs, dtype=np.int64)  # noqa: E731
+
+        with pytest.raises(ValueError, match="child_indptr"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(0), i64(0), i64(1), i64(0)
+            )
+        with pytest.raises(ValueError, match="start at 0"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(0, 1), i64(1, 1, 1), i64(1), i64(0)
+            )
+        with pytest.raises(ValueError, match="non-decreasing"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(0, 1), i64(0, 2, 1), i64(1), i64(0)
+            )
+        with pytest.raises(ValueError, match="parent_idx"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(3), i64(0, 1), i64(1), i64(0)
+            )
+        with pytest.raises(ValueError, match="child_idx"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(0), i64(0, 1), i64(3), i64(0)
+            )
+        with pytest.raises(ValueError, match="top_idx"):
+            _lib_recon._forecast_proportions_traversal(
+                y, i64(0), i64(0, 1), i64(1), i64(-1)
+            )


### PR DESCRIPTION

> **STACKED PR — do not merge before #494.** This branch (`perf/native-forecast-proportions-traversal`) is built on top of `perf/vectorize-probabilistic-and-proportions` (PR #494) and reuses its vectorized `_get_child_nodes` and its test infrastructure (`_make_random_strict_hierarchy` in `tests/conftest.py`, the benchmark suite layout, and the CI benchmark exclusion). After #494 merges, rebase this branch onto `main` (or retarget the PR) — only the four commits ending at `test: add regression tests and benchmarks for native traversal` belong to this PR.

## What

`TopDown`/`MiddleOut` with `method="forecast_proportions"` reconciled forecasts with a 4-level nested pure-Python tree traversal (`_reconcile_fcst_proportions` in `hierarchicalforecast/methods.py`: top nodes x levels x parents x children, scalar numpy ops in the innermost loop). That traversal was re-executed:

- once per horizon column in `TopDown.fit_predict` (`for y_hat_ in y_hat.T`),
- once per **bootstrap sample x horizon column** for prediction intervals (`_reconcile_fcst_proportions_bootstrap`) — a 100–10,000x multiplier on the traversal count (`num_samples` defaults to 100 and is commonly 1,000+),
- and `MiddleOut` repeats all of the above once per cut node.

This PR moves the traversal into the existing pybind11/Eigen C++ extension as a batched kernel that processes **all (sample, horizon) pairs in one call**, and wires the dense `TopDown`/`MiddleOut` mean and bootstrap paths through it. The pure-Python implementation stays in `methods.py` as the behavioral reference for the regression tests. The sparse path (`_reconcile_fcst_proportions_sparse`, used by `TopDownSparse`/`MiddleOutSparse`) is untouched — it is already vectorized per column with sparse matmuls and would need sparse-matrix plumbing into C++; it can be a follow-up if it shows up in profiles.

## Why

For a hierarchy with `n` nodes and `h`-step forecasts, the old path performed `O(n)` Python-level scalar numpy operations per traversal and `h * num_samples` traversals per `fit_predict` with intervals. On the benchmark hierarchy below (1,021 nodes, `h=12`, 1,000 samples) that is 12,000 Python traversals ≈ 25M Python-level numpy scalar ops — 36 seconds of pure interpreter overhead for ~0.3s of actual arithmetic.

## How

### Flattening (once per `fit_predict`)

`_flatten_child_nodes` converts the `_get_child_nodes` output (`{level: {parent: [children]}}`, already vectorized on #494) into three CSR-style int64 arrays: `parent_idx` (parents in traversal order: levels top-to-bottom, insertion order within a level), `child_indptr`, and `child_idx`. A single flat pass over that parent list is exactly equivalent to the reference's level-by-level traversal because every parent's reconciled value is written (as a top node, or as a child at the previous level) before it is read. Level offsets therefore don't need to be passed to the kernel at all. The same flattening also showed the reference's outer `for idx_top in idxs_top` loop is redundant re-computation: the final pass is identical to seeding all top nodes once and traversing once, which is what the kernel does.

### Kernel (`src/forecast_proportions.cpp`, new translation unit)

`_forecast_proportions_traversal(samples (S, n, h), parent_idx, child_indptr, child_idx, top_idx) -> (S, n, h)` follows the existing binding patterns in `src/reconciliation.cpp` (same submodule, `unchecked` buffers, GIL released around the compute region, input validation with `ValueError` on malformed/out-of-bounds flat arrays). The mean path calls it with `S=1`; the bootstrap path materializes all `num_samples` base-forecast matrices with one vectorized numpy gather+add and reconciles them in one call.

### Bit-exactness strategy

The goal was exact float equality with the pure-Python reference, not allclose:

- **Child sums**: the reference computes `y_hat[idx_childs].sum()` — NumPy's pairwise summation over a contiguous child-ordered vector. The kernel ports `DOUBLE_pairwise_sum` from `numpy/_core/src/umath/loops_utils.h.src` faithfully (sequential under 8 elements including the `-0.0` seed, the 8-accumulator unrolled block with its exact combination tree up to 128, recursive split rounded to a multiple of 8 above). NumPy ships that reduction as a single generic C source with no per-architecture SIMD dispatch variant — the unroll is explicitly designed so compilers can vectorize it *without changing summation order* — so the association tree is platform-independent. (Empirically necessary: NumPy's own `sum(axis=...)` over 2D/3D gathers diverges from the 1-D contiguous form in the last ulp for fan-outs ≥ 8, so precomputing the sums with batched numpy reductions was tried first and abandoned.)
- **Scalar chain**: the per-child update is the reference's `y * fcst_parent / childs_sum` (and `fcst_parent / n_children` under the `|sum| < 1e-8` guard) in the same operation order.
- **Fast-math containment (per-source build flags, not pragmas)**: the extension builds with `-ffast-math` (`/fp:fast` on MSVC), which would license reciprocal hoisting of the loop-invariant divisor (`x/s -> x * (1/s)`), reassociation, FP contraction — all last-ulp-changing — and, via finite-math-only, lets the compiler assume no NaN/inf. That last one is not a last-ulp issue but a correctness bug: with `-ffast-math` on clang the kernel's `|child_sum| < 1e-8` guard was allowed to assume the sum is never NaN, so a NaN child forecast (e.g. `y_hat = [10, 1, NaN, 2]` on a star hierarchy) silently took the equal-split branch and produced finite output (`[10, 3.33, 3.33, 3.33]`) where the Python reference propagates NaN (`[10, nan, nan, nan]`). In-file FP pragmas cannot fully undo a driver-level `-ffast-math` on every toolchain (clang's scoped pragmas in particular do not restore NaN semantics), so `setup.py` now excludes `src/forecast_proportions.cpp` from fast-math at the build level: a small `build_ext` override (`STRICT_FP_SOURCES`) appends per-source flags — `-fno-fast-math` on gcc/clang (the later flag wins over the earlier `-ffast-math`), `/fp:precise` on MSVC (same later-flag-wins rule over `/fp:fast`). The existing kernels' flags are untouched, and the in-file pragmas are kept as defense-in-depth only. NaN and inf + -inf child-sum propagation is pinned by regression tests, exact-equal against the reference.

### OpenMP parallelism boundaries

Parallelism spans **only the fully independent (sample, horizon) pairs** (flattened into one loop by hand — MSVC's OpenMP 2.0 has no `collapse`). No accumulation ever crosses a thread boundary and each pair writes disjoint output entries, so the result is deterministic and bit-identical to a serial run for any thread count (asserted: 1 thread vs 10 threads, `np.array_equal`).

## Benchmarks

Measured on this branch (arm64 macOS, 10 OpenMP threads, Python 3.12, numpy 2.3.5), `pytest tests/test_benchmarks.py -k fcst_proportions` — synthetic strict hierarchy with 1,000 bottom series, 3 levels (1,021 nodes), `h=12`:

| Workload | Python (before) | Native (after) | Speedup |
| --- | --- | --- | --- |
| Mean path (12 columns) | 45.3 ms | 0.311 ms | **~146x** |
| Bootstrap intervals, 100 samples | 3.62 s | 71.6 ms | **~51x** |
| Bootstrap intervals, 1,000 samples (one-off timing) | 36.12 s | 0.855 s | **~42x** |

The 1,000-sample outputs of the two implementations are bit-identical (`np.array_equal` on the returned quantiles). At 1,000 samples the native path's remaining time is dominated by `np.quantile` over the `(1021, 12, 1000)` sample tensor, not the traversal. The benchmark suite keeps the parametrized python-vs-native pairs at sizes that run in seconds (the 100-sample python case uses `benchmark.pedantic(rounds=3)`) plus a native-only 1,000-sample case; benchmarks remain excluded from the CI wheel matrix via `-m "not benchmark"` (from #494).

## Testing

- `TestForecastProportionsNative` in `tests/test_methods.py` (20 tests, all **exact equality** via `assert_array_equal`, no allclose):
  - fuzz vs the per-column Python reference over random strict hierarchies (`_make_random_strict_hierarchy`, crc32-derived seeds), covering fan-outs below 8 (sequential summation), above 8 (unrolled block), and a 200-child parent (recursive pairwise split above the 128 block size);
  - zero-children-sum branch (exact 0.0 and below-threshold 1e-10 sums), partial top-node seeding leaving unseeded subtrees untouched, batched-vs-single-sample consistency;
  - non-finite propagation: a NaN child and an inf + -inf child pair both poison the child sum and must propagate NaN exactly like the reference (the fast-math regression guard described above);
  - float32 fallback: non-float64 input matches the pre-native Python path bit-for-bit and preserves dtype end-to-end, on the direct call, the public `TopDown` mean path, and the bootstrap path;
  - end-to-end public API equivalence for `TopDown` and `MiddleOut` (fixture + random hierarchy) by monkeypatching `_reconcile_fcst_proportions_native` with a wrapper that routes every (sample, column) through the pure-Python `_reconcile_fcst_proportions`;
  - seeded bootstrap quantile equality (direct call and end-to-end through `TopDown(..., intervals_method="bootstrap")`, mean and quantiles);
  - kernel input validation (malformed `child_indptr` shape, `child_indptr[0] != 0`, non-decreasing violation, out-of-bounds parent/child/top indices all raise `ValueError`).
- Full suites green locally: `tests/test_methods.py` + `tests/test_probabilistic_methods.py` (206 passed), `tests/test_utils.py` (15 passed). (`tests/test_core.py`/`tests/test_evaluation.py` dataset-download fixtures fail in this sandboxed environment on the base branch already — network-restricted, unrelated.)
- Local extension build: compiles clean (arm64 clang, OpenMP via libomp); thread-count determinism asserted at 1 vs 10 threads.

## Notes for reviewers

- **Native for float64, Python reference for everything else** — the kernel computes in float64 only, and pybind11's `forcecast` would otherwise silently upcast e.g. float32 `y_hat` from direct `TopDown`/`MiddleOut` callers, changing both the arithmetic and the output dtype. `_reconcile_fcst_proportions_native` therefore gates on dtype: non-float64 input falls back to the retained pure-Python reference, reproducing the pre-native behavior exactly in the input's native dtype. `core.reconcile` coerces base forecasts to float64 upstream, so the main `reconcile()` path always takes the kernel — the gate only affects direct callers. (For float64, this matches how `_ma_cov`/`_lasso`/the Schafer–Strimmer kernels were ported: `_lib` is called unconditionally, no runtime fallback.)
- **Bootstrap memory scaling**: the dense bootstrap path materializes all base-forecast samples as one `(num_samples, n_nodes, h)` float64 tensor before the single kernel call. At the default 100 samples this is negligible, but at 10,000 samples on a large hierarchy (say 50k nodes, `h=12`) it is tens of GB — multi-GB territory starts around a few thousand samples on 10k+-node hierarchies. Chunking the sample axis (reconciling in fixed-size batches and streaming into the quantile buffer) is the natural follow-up if that becomes a real workload; the kernel already accepts arbitrary sample batch sizes, so no C++ changes would be needed.
- The `flat` tuple is threaded through `_reconcile_fcst_proportions_bootstrap` as an optional argument (computed once in `fit_predict`, alongside the existing `nodes`/`idxs_top`), so the public signature stays backward compatible.
- Cross-platform bit-exactness rests on NumPy's pairwise summation being the single generic C implementation described above (verified against numpy 2.3.5 sources and exhaustively size-swept locally; numpy >= 1.21 checked for the no-SIMD-variant claim, and numpy < 2.0's `0.` vs `-0.0` seed difference in the < 8 base case is unobservable through the `|sum| < 1e-8` guard). If a future NumPy release ever changes that reduction, the exact-equality fuzz tests will catch it loudly rather than silently drifting.
- The local-build libomp architecture caveat from #494 (an x86_64-prefix Homebrew on an arm64 machine resolving `brew --prefix libomp` to the wrong-arch dylib; fixed locally with the arm64 `libomp` bottle and an `ARCHFLAGS="-arch arm64"`-only build) applies to this branch's extension build too.
