### PR TITLE
docs: fix confirmed language errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 ## 📚 Intro
-A vast amount of time series datasets are organized into structures with different levels or hierarchies of aggregation. Examples include cross-sectional aggregations such as categories, brands, or geographical groupings, or temporal aggregations such as weeks, months or years. Coherent forecasts across levels are necessary for consistent decision-making and planning. Hierachical Forecast offers different reconciliation methods that render coherent forecasts across cross-sectional and temporal hierachies.
+A vast number of time series datasets are organized into structures with different levels or hierarchies of aggregation. Examples include cross-sectional aggregations such as categories, brands, or geographical groupings, or temporal aggregations such as weeks, months or years. Coherent forecasts across levels are necessary for consistent decision-making and planning. Hierarchical Forecast offers different reconciliation methods that render coherent forecasts across cross-sectional and temporal hierarchies.
 
 ## 🎊 Features
 
@@ -60,7 +60,7 @@ pip install hierarchicalforecast
 ## 🧬 How to use
 
 The following example needs `statsforecast` and `datasetsforecast` as additional packages. If not installed, install it via your preferred method, e.g. `pip install statsforecast datasetsforecast`.
-The `datasetsforecast` library allows us to download hierarhical datasets and we will use `statsforecast` to compute the base forecasts to be reconciled.
+The `datasetsforecast` library allows us to download hierarchical datasets and we will use `statsforecast` to compute the base forecasts to be reconciled.
 
 You can open a complete example in Colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nixtla/hierarchicalforecast/blob/main/nbs/examples/TourismSmall.ipynb)
 

--- a/docs/core.html.md
+++ b/docs/core.html.md
@@ -45,7 +45,7 @@ df.insert(0, 'Country', 'Australia')
 qs = df['ds'].str.replace(r'(\d+) (Q\d)', r'\1-\2', regex=True)
 df['ds'] = pd.PeriodIndex(qs, freq='Q').to_timestamp()
 
-# Create hierarchical seires based on geographic levels and purpose
+# Create hierarchical series based on geographic levels and purpose
 # And Convert quarterly ds string to pd.datetime format
 hierarchy_levels = [['Country'],
                     ['Country', 'State'],

--- a/docs/evaluation.html.md
+++ b/docs/evaluation.html.md
@@ -35,7 +35,7 @@ df.insert(0, 'Country', 'Australia')
 qs = df['ds'].str.replace(r'(\d+) (Q\d)', r'\1-\2', regex=True)
 df['ds'] = pd.PeriodIndex(qs, freq='Q').to_timestamp()
 
-# Create hierarchical seires based on geographic levels and purpose
+# Create hierarchical series based on geographic levels and purpose
 # And Convert quarterly ds string to pd.datetime format
 hierarchy_levels = [['Country'],
                     ['Country', 'State'],

--- a/docs/utils.html.md
+++ b/docs/utils.html.md
@@ -9,7 +9,7 @@ and visualize hierarchical series datasets. The
 [`aggregate`](https://nixtlaverse.nixtla.io/hierarchicalforecast/utils.html#aggregate)
 function of the module allows you to create a hierarchy from categorical
 variables representing the structure levels, returning also the
-aggregation contraints matrix $\mathbf{S}$.
+aggregation constraints matrix $\mathbf{S}$.
 
 In addition, `HierarchicalForecast` ensures compatibility of its
 reconciliation methods with other popular machine-learning libraries via

--- a/nbs/examples/australiandomestictourism-bootstraped-intervals.ipynb
+++ b/nbs/examples/australiandomestictourism-bootstraped-intervals.ipynb
@@ -200,7 +200,7 @@
    "source": [
     "Using the `aggregate` function from `HierarchicalForecast` we can generate:\n",
     "1. `Y_df`: the hierarchical structured series $\\mathbf{y}_{[a,b]\\tau}$\n",
-    "2. `S_df`: the aggregation constraings dataframe with $S_{[a,b]}$\n",
+    "2. `S_df`: the aggregation constraints dataframe with $S_{[a,b]}$\n",
     "3. `tags`: a list with the 'unique_ids' conforming each aggregation level."
    ]
   },
@@ -909,7 +909,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot hierarchichally linked time series"
+    "### Plot hierarchically linked time series"
    ]
   },
   {

--- a/nbs/examples/australiandomestictourism-intervals.ipynb
+++ b/nbs/examples/australiandomestictourism-intervals.ipynb
@@ -200,7 +200,7 @@
    "source": [
     "Using the `aggregate` function from `HierarchicalForecast` we can generate:\n",
     "1. `Y_df`: the hierarchical structured series $\\mathbf{y}_{[a,b]\\tau}$\n",
-    "2. `S_df`: the aggregation constraings dataframe with $S_{[a,b]}$\n",
+    "2. `S_df`: the aggregation constraints dataframe with $S_{[a,b]}$\n",
     "3. `tags`: a list with the 'unique_ids' conforming each aggregation level."
    ]
   },
@@ -936,7 +936,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot hierarchichally linked time series"
+    "### Plot hierarchically linked time series"
    ]
   },
   {

--- a/nbs/examples/australiandomestictourism-permbu-intervals.ipynb
+++ b/nbs/examples/australiandomestictourism-permbu-intervals.ipynb
@@ -915,7 +915,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot hierarchichally linked time series"
+    "### Plot hierarchically linked time series"
    ]
   },
   {

--- a/nbs/examples/australiandomestictourismcrosstemporal.ipynb
+++ b/nbs/examples/australiandomestictourismcrosstemporal.ipynb
@@ -1343,7 +1343,7 @@
     "\n",
     "We can again use the `HierarchicalReconciliation` class to reconcile the forecasts. In this example we use `BottomUp` and `MinTrace`. Note that we have to set `temporal=True` in the `reconcile` function.\n",
     "\n",
-    "Note that temporal reconcilation currently isn't supported for insample reconciliation methods, such as `MinTrace(method='mint_shrink')`."
+    "Note that temporal reconciliation currently isn't supported for insample reconciliation methods, such as `MinTrace(method='mint_shrink')`."
    ]
   },
   {

--- a/nbs/examples/australiandomestictourismtemporal.ipynb
+++ b/nbs/examples/australiandomestictourismtemporal.ipynb
@@ -1176,7 +1176,7 @@
     "\n",
     "We can use the `HierarchicalReconciliation` class to reconcile the forecasts. In this example we use `BottomUp` and `MinTrace`. Note that we have to set `temporal=True` in the `reconcile` function.\n",
     "\n",
-    "Note that temporal reconcilation currently isn't supported for insample reconciliation methods, such as `MinTrace(method='mint_shrink')`."
+    "Note that temporal reconciliation currently isn't supported for insample reconciliation methods, such as `MinTrace(method='mint_shrink')`."
    ]
   },
   {

--- a/nbs/examples/installation.ipynb
+++ b/nbs/examples/installation.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Install | HierarchicalForecast\n",
     "\n",
-    "> Install HierachicalForecast with pip or conda"
+    "> Install HierarchicalForecast with pip or conda"
    ]
   },
   {
@@ -19,7 +19,7 @@
    "source": [
     "We recommend using `uv` as Python package manager, for which you can find installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/).\n",
     "\n",
-    "You can then install the *released version* of `HierachicalForecast`:\n",
+    "You can then install the *released version* of `HierarchicalForecast`:\n",
     "\n",
     "```python\n",
     "uv pip install hierarchicalforecast\n",
@@ -44,7 +44,7 @@
     "\n",
     "We recommend using `uv` as Python package manager, for which you can find installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/).\n",
     "\n",
-    "1. Clone the HierachicalForecast repo: \n",
+    "1. Clone the HierarchicalForecast repo: \n",
     "\n",
     "```bash \n",
     "$ git clone https://github.com/Nixtla/hierarchicalforecast.git && cd hierarchicalforecast\n",

--- a/nbs/examples/tourismlarge-evaluation.ipynb
+++ b/nbs/examples/tourismlarge-evaluation.ipynb
@@ -341,7 +341,7 @@
    "source": [
     "",
     "with CodeTimer('Fit/Predict Model     ', verbose):\n",
-    "    # Read to avoid unnecesary AutoARIMA computation\n",
+    "    # Read to avoid unnecessary AutoARIMA computation\n",
     "    yhat_file = f'./data/{dataset}/Y_hat.csv'\n",
     "    yfitted_file = f'./data/{dataset}/Y_fitted.csv'\n",
     "\n",


### PR DESCRIPTION
## What

Corrects confirmed spelling and grammar errors in HierarchicalForecast documentation, examples, and generated reference pages.

## Why

The public documentation audit found objective language mistakes that reduce clarity and search quality.

## How

1. Correct product name and hierarchy terminology.
2. Correct spelling in reconciliation examples and reference content.
3. Preserve code behavior, notebook outputs, and page structure.

## Testing

1. Parsed every changed notebook as valid JSON.
2. Confirmed the reported mistakes no longer appear in the changed public content.
3. Ran `git diff --check` and reviewed the complete diff.
4. Scanned additions for credentials and unintended files.

## Checklist

1. Title follows conventional commit format.
2. The pull request is limited to documentation language corrections.
3. The complete diff was reviewed.
4. No secrets, credentials, or personal data were added.